### PR TITLE
ci: Add Build and test GitHub Action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Build and test
+
+on: [push,pull_request]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-22.04
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '18'
+
+    - name: Install dependencies
+      run: |
+        npm install --location global pnpm
+        pnpm install
+
+    - name: Build
+      run: |
+        pnpm build
+
+    - name: Test
+      run: |
+        pnpm test
+
+    # Not quite read for automated publication
+    #- name: Publish
+      #env:
+        #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        #NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #run: |
+        #git config --global user.name "GitHub Actions"
+        #git config --global user.email "itk+community@discourse.itk.org"
+        #npx semantic-release


### PR DESCRIPTION
Towards #5 . Does not deploy -- can enable when until we have minimal functionality.