### PR TITLE
Remote MultiscaleSpatialImage for image scale changing

### DIFF
--- a/.changeset/cold-rocks-try.md
+++ b/.changeset/cold-rocks-try.md
@@ -1,0 +1,10 @@
+---
+'@itk-viewer/remote-viewport': patch
+'@itk-viewer/blosc-zarr': patch
+'@itk-viewer/wasm-utils': patch
+'@itk-viewer/element': patch
+'@itk-viewer/viewer': patch
+'@itk-viewer/io': patch
+---
+
+Route MultiscaleSpatialImages through Viewport actor to RemoteViewport actor.

--- a/cypress/support/component-index.html
+++ b/cypress/support/component-index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <meta charset="utf-8" />

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -10,11 +10,11 @@ declare global {
       // infer cy.wrap return type: https://github.com/cypress-io/cypress/issues/18182
       wrap<E extends Node = HTMLElement>(
         element: E | JQuery<E>,
-        options?: Partial<Loggable & Timeoutable>
+        options?: Partial<Loggable & Timeoutable>,
       ): Chainable<JQuery<E>>;
       wrap<S>(
         object: S | Promise<S>,
-        options?: Partial<Loggable & Timeoutable>
+        options?: Partial<Loggable & Timeoutable>,
       ): Chainable<S>;
     }
   }

--- a/package.json
+++ b/package.json
@@ -22,18 +22,18 @@
   "devDependencies": {
     "@changesets/cli": "^2.26.2",
     "@cypress/mount-utils": "^4.0.0",
-    "@typescript-eslint/eslint-plugin": "^5.59.8",
-    "@typescript-eslint/parser": "^5.59.8",
-    "cypress": "^12.13.0",
-    "cypress-lit": "^0.0.7",
-    "eslint": "^8.41.0",
+    "@typescript-eslint/eslint-plugin": "^6.5.0",
+    "@typescript-eslint/parser": "^6.5.0",
+    "cypress": "^13.0.0",
+    "cypress-lit": "^0.0.8",
+    "eslint": "^8.48.0",
     "follow-redirects": "^1.15.2",
-    "lit": "^2.7.5",
-    "prettier": "^2.8.8",
+    "lit": "^2.8.0",
+    "prettier": "^3.0.3",
     "tar": "^6.1.15",
-    "typescript": "^5.1.3",
-    "vite": "^4.3.9",
-    "vite-plugin-static-copy": "^0.15.0"
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9",
+    "vite-plugin-static-copy": "^0.17.0"
   },
   "prettier": {
     "singleQuote": true

--- a/packages/blosc-zarr/package.json
+++ b/packages/blosc-zarr/package.json
@@ -39,11 +39,11 @@
   },
   "homepage": "https://github.com/InsightSoftwareConsortium/itk-viewer#readme",
   "devDependencies": {
-    "typescript": "^4.8.4"
+    "typescript": "^5.2.2"
   },
   "dependencies": {
     "@itk-viewer/wasm-utils": "workspace:^",
-    "itk-wasm": "1.0.0-b.112"
+    "itk-wasm": "1.0.0-b.133"
   },
   "eslintConfig": {
     "env": {

--- a/packages/element/index.html
+++ b/packages/element/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -55,6 +55,7 @@
     "gl-matrix": "^3.4.3",
     "lit": "^2.8.0",
     "orbit-camera": "^1.0.0",
+    "xstate": "5.0.0-beta.24",
     "xstate-lit": "^1.3.1"
   }
 }

--- a/packages/element/package.json
+++ b/packages/element/package.json
@@ -45,15 +45,15 @@
   },
   "homepage": "https://github.com/InsightSoftwareConsortium/itk-viewer#readme",
   "devDependencies": {
-    "typescript": "^5.0.4",
-    "vite": "^4.3.9"
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
   },
   "dependencies": {
     "@itk-viewer/io": "workspace:^",
     "@itk-viewer/remote-viewport": "workspace:^",
     "@itk-viewer/viewer": "workspace:^",
     "gl-matrix": "^3.4.3",
-    "lit": "^2.7.4",
+    "lit": "^2.8.0",
     "orbit-camera": "^1.0.0",
     "xstate-lit": "^1.3.1"
   }

--- a/packages/element/src/image-info-viewport.ts
+++ b/packages/element/src/image-info-viewport.ts
@@ -10,7 +10,7 @@ export class ImageInfoViewport extends ItkViewport {
   image = new SelectorController(
     this,
     this.actor,
-    (state) => state?.context.image
+    (state) => state?.context.image,
   );
 
   render() {
@@ -21,7 +21,7 @@ export class ImageInfoViewport extends ItkViewport {
     const imageInfo = `Image Type: ${JSON.stringify(
       imageType,
       null,
-      2
+      2,
     )}\nSpatial Dimensions: ${spatialDims}\nDirection: ${direction}`;
 
     return html`

--- a/packages/element/src/itk-camera.ts
+++ b/packages/element/src/itk-camera.ts
@@ -2,20 +2,19 @@ import { LitElement, PropertyValues, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { ReadonlyMat4, mat4 } from 'gl-matrix';
 import createOrbitCamera from 'orbit-camera';
+import type { OrbitCamera } from 'orbit-camera';
 
 import { Viewport } from '@itk-viewer/viewer/viewport.js';
 import { Camera, createCamera } from '@itk-viewer/viewer/camera-machine.js';
 import { Ref, createRef, ref } from 'lit/directives/ref.js';
 
-type OrbitCameraController = ReturnType<typeof createOrbitCamera>;
-
 const PAN_SPEED = 1;
 const ZOOM_SPEED = 0.0002;
 
 const bindCamera = (
-  camera: OrbitCameraController,
+  camera: OrbitCamera,
   viewport: HTMLElement,
-  onUpdate: (view: ReadonlyMat4) => unknown
+  onUpdate: (view: ReadonlyMat4) => unknown,
 ) => {
   let width = viewport.clientWidth;
   let height = viewport.clientHeight;
@@ -74,7 +73,7 @@ const bindCamera = (
     if (rotate) {
       camera.rotate(
         [mouseX / width - 0.5, mouseY / height - 0.5],
-        [prevMouseX / width - 0.5, prevMouseY / height - 0.5]
+        [prevMouseX / width - 0.5, prevMouseY / height - 0.5],
       );
     }
 
@@ -130,7 +129,7 @@ export class ItkCamera extends LitElement {
   viewport: Viewport | undefined;
 
   camera: Camera;
-  cameraController: OrbitCameraController;
+  cameraController: OrbitCamera;
   unbind: (() => unknown) | undefined;
   container: Ref<HTMLElement> = createRef();
 
@@ -141,7 +140,7 @@ export class ItkCamera extends LitElement {
     this.cameraController = createOrbitCamera(
       [-0.747528, -0.570641, 0.754992],
       [0.5, 0.5, 0.5],
-      [-0.505762, 0.408327, -0.759916]
+      [-0.505762, 0.408327, -0.759916],
     );
 
     const pose = this.cameraController.view();

--- a/packages/element/src/itk-remote-viewport.ts
+++ b/packages/element/src/itk-remote-viewport.ts
@@ -3,6 +3,7 @@ import { PropertyValues, css, html } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { Ref, createRef, ref } from 'lit/directives/ref.js';
 import { SelectorController } from 'xstate-lit/dist/select-controller.js';
+import { ActorStatus } from 'xstate';
 
 import {
   RemoteActor,
@@ -48,6 +49,11 @@ export class ItkRemoteViewport extends ItkViewport {
   canvasHeight = 0;
 
   remote: RemoteActor;
+
+  remoteOnline: SelectorController<RemoteActor, boolean>;
+  lastRemoteOnlineValue = false;
+  renderLoopRunning = false;
+
   frame: SelectorController<RemoteActor, Image | undefined>;
   lastFrameValue: Image | undefined = undefined;
 
@@ -56,10 +62,15 @@ export class ItkRemoteViewport extends ItkViewport {
     const { remote, viewport } = createRemoteViewport(createHyphaActors());
     this.actor = viewport;
     this.remote = remote;
+    this.remoteOnline = new SelectorController(
+      this,
+      this.remote,
+      (state) => state?.matches('root.online') ?? false,
+    );
     this.frame = new SelectorController(
       this,
       this.remote,
-      (state) => state?.context.frame
+      (state) => state?.context.frame,
     );
   }
 
@@ -75,11 +86,15 @@ export class ItkRemoteViewport extends ItkViewport {
     this.canvasCtx.putImageData(imageData, 0, 0);
   }
 
-  connectedCallback() {
-    super.connectedCallback();
+  startRenderLoop() {
+    if (this.renderLoopRunning || !this.remoteOnline.value) return;
+    this.renderLoopRunning = true;
 
     const render = () => {
-      if (!this.isConnected) return;
+      if (!this.isConnected || this.remote.status === ActorStatus.Stopped) {
+        this.renderLoopRunning = false;
+        return;
+      }
 
       this.remote.send({ type: 'render' });
       requestAnimationFrame(render);
@@ -87,7 +102,12 @@ export class ItkRemoteViewport extends ItkViewport {
     requestAnimationFrame(render);
   }
 
-  firstUpdated(): void {
+  connectedCallback() {
+    super.connectedCallback();
+    this.startRenderLoop();
+  }
+
+  firstUpdated() {
     const canvas = this.canvas.value;
     if (!canvas) throw new Error('canvas not found');
     this.canvasCtx = canvas.getContext('2d');
@@ -132,6 +152,13 @@ export class ItkRemoteViewport extends ItkViewport {
     if (this.frame.value && this.frame.value !== this.lastFrameValue) {
       this.lastFrameValue = this.frame.value;
       this.putFrame();
+    }
+
+    if (this.remoteOnline.value !== this.lastRemoteOnlineValue) {
+      this.lastRemoteOnlineValue = this.remoteOnline.value;
+      if (this.remoteOnline.value) {
+        this.startRenderLoop();
+      }
     }
   }
 

--- a/packages/element/src/itk-remote-viewport.ts
+++ b/packages/element/src/itk-remote-viewport.ts
@@ -15,19 +15,6 @@ import { Image } from '@itk-viewer/remote-viewport/types.js';
 import { ItkViewport } from './itk-viewport.js';
 import './itk-camera.js';
 
-const makeMultiscaleImage = (image: string) => {
-  if (image.endsWith('.tif')) {
-    return {
-      scaleCount: 1,
-      scale: 0,
-    };
-  }
-  return {
-    scaleCount: 8,
-    scale: 7,
-  };
-};
-
 @customElement('itk-remote-viewport')
 export class ItkRemoteViewport extends ItkViewport {
   @property({ type: Object, attribute: 'server-config' })
@@ -125,21 +112,6 @@ export class ItkRemoteViewport extends ItkViewport {
   willUpdate(changedProperties: PropertyValues<this>) {
     if (changedProperties.has('serverConfig')) {
       this.startConnection();
-    }
-
-    if (changedProperties.has('image')) {
-      if (this.image) {
-        const multiscaleImage = makeMultiscaleImage(this.image);
-        this.remote.send({
-          type: 'setMultiscaleImage',
-          image: multiscaleImage,
-        });
-
-        this.remote.send({
-          type: 'updateRenderer',
-          props: { image: this.image },
-        });
-      }
     }
 
     if (changedProperties.has('density')) {

--- a/packages/element/src/itk-viewport.ts
+++ b/packages/element/src/itk-viewport.ts
@@ -1,10 +1,12 @@
+import { viewportMachine } from '@itk-viewer/viewer/viewport-machine.js';
 import { createViewport } from '@itk-viewer/viewer/viewport.js';
 import { LitElement, css, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
+import { ActorRefFrom } from 'xstate';
 
 @customElement('itk-viewport')
 export class ItkViewport extends LitElement {
-  actor = createViewport();
+  actor: ActorRefFrom<typeof viewportMachine> = createViewport();
 
   constructor() {
     super();

--- a/packages/element/src/main.ts
+++ b/packages/element/src/main.ts
@@ -1,23 +1,23 @@
-import { ZarrMultiscaleSpatialImage } from '@itk-viewer/io/ZarrMultiscaleSpatialImage.js';
+import { makePlaceholderMultiscaleImage } from '@itk-viewer/io/makePlaceholderMultiscaleImage.js';
 import { ItkViewport } from './itk-viewport.js';
 
-const imagePath = '/ome-ngff-prototypes/single_image/v0.4/zyx.ome.zarr';
-const url = new URL(imagePath, document.location.origin);
-const image = await ZarrMultiscaleSpatialImage.fromUrl(url);
+// Remote image placeholders for FPS pyramid-scale switching
+const makeMultiscaleImage = (image: string) => {
+  if (image.endsWith('.tif')) {
+    return makePlaceholderMultiscaleImage(image, 1);
+  }
+  return makePlaceholderMultiscaleImage(image, 8);
+};
+
+const imagePath = import.meta.env.VITE_IMAGE;
+const image = makeMultiscaleImage(imagePath);
 
 const viewerElement = document.querySelector('itk-viewer');
 if (!viewerElement) throw new Error('Could not find element');
 const viewer = viewerElement.getActor();
 
-// const leftViewport = document.querySelector(
-//   '#left-viewport'
-// ) as ItkViewport | null;
-// if (!leftViewport) throw new Error('Could not find element');
-// const leftV = leftViewport.getActor();
-// viewer.send({ type: 'addViewport', viewport: leftV, name: 'left' });
-
 const rightViewport = document.querySelector(
-  '#right-viewport'
+  '#right-viewport',
 ) as ItkViewport | null;
 if (!rightViewport) throw new Error('Could not find element');
 const rightV = rightViewport.getActor();

--- a/packages/element/src/orbit-camera.d.ts
+++ b/packages/element/src/orbit-camera.d.ts
@@ -1,7 +1,17 @@
 declare module 'orbit-camera' {
+  import { ReadonlyMat4, mat4, ReadonlyVec2, ReadonlyVec3 } from 'gl-matrix';
+
+  export type OrbitCamera = {
+    view: (outMat?: mat4) => ReadonlyMat4;
+    rotate: (da: ReadonlyVec2, db: ReadonlyVec2) => void;
+    pan: (dpan: ReadonlyVec2 | ReadonlyVec3) => void;
+    zoom: (delta: number) => void;
+    distance: number;
+  };
+
   export default function createOrbitCamera(
     eye: number[],
     target: number[],
-    up: number[]
-  ): any;
+    up: number[],
+  ): OrbitCamera;
 }

--- a/packages/io/package.json
+++ b/packages/io/package.json
@@ -41,17 +41,17 @@
   },
   "homepage": "https://github.com/InsightSoftwareConsortium/itk-viewer#readme",
   "devDependencies": {
-    "typescript": "^5.1.3"
+    "typescript": "^5.2.2"
   },
   "dependencies": {
     "@itk-viewer/blosc-zarr": "workspace:^",
     "@itk-viewer/wasm-utils": "workspace:^",
-    "axios": "^1.4.0",
+    "axios": "^1.5.0",
     "gl-matrix": "^3.4.3",
-    "itk-wasm": "1.0.0-b.112",
+    "itk-wasm": "1.0.0-b.133",
     "p-queue": "^7.3.4",
     "webworker-promise": "^0.5.1",
-    "zod": "^3.21.4"
+    "zod": "^3.22.2"
   },
   "eslintConfig": {
     "env": {

--- a/packages/io/src/ImageDataFromChunks.worker.js
+++ b/packages/io/src/ImageDataFromChunks.worker.js
@@ -14,7 +14,7 @@ const haveSharedArrayBuffer = typeof self.SharedArrayBuffer === 'function';
 const validateIndices = ({ chunkStart, chunkEnd, roiStart, roiEnd }) => {
   if (
     ['x', 'y', 'z'].some(
-      (dim) => chunkStart[dim] > roiEnd[dim] || chunkEnd[dim] < roiStart[dim]
+      (dim) => chunkStart[dim] > roiEnd[dim] || chunkEnd[dim] < roiStart[dim],
     )
   ) {
     // We should never get here...
@@ -40,7 +40,7 @@ const makeImageDataFromChunks = ({
   const pixelArrayType = componentTypeToTypedArray.get(imageType.componentType);
   let pixelArray = null;
   const pixelArrayElements = Array.from(info.arrayShape.values()).reduce(
-    (a, b) => a * b
+    (a, b) => a * b,
   );
   if (haveSharedArrayBuffer) {
     const pixelArrayBytes =
@@ -69,7 +69,7 @@ const makeImageDataFromChunks = ({
         { [dim]: size, ...strides },
         size * dimSize,
       ],
-      [{}, 1]
+      [{}, 1],
     );
 
   for (let index = 0; index < chunkIndices.length; index++) {
@@ -108,7 +108,7 @@ const makeImageDataFromChunks = ({
     // write pixels at the start of the output image, not where they start in source image
     const roiStartPixelOffset = Object.keys(pixelStrides).reduce(
       (offset, dim) => offset + pixelStrides[dim] * roiStart[dim],
-      0
+      0,
     );
 
     // Does input data group component(s) with each pixel?
@@ -135,7 +135,7 @@ const makeImageDataFromChunks = ({
             zChunkOffset;
           const subarray = typedChunk.subarray(
             yChunkOffset,
-            yChunkOffset + itEnd.c * (itEnd.x - itStart.x)
+            yChunkOffset + itEnd.c * (itEnd.x - itStart.x),
           );
           const pixelOffset =
             itStart.x * pixelStrides.x + // chunk's x index mapped to image's x index
@@ -160,7 +160,7 @@ const makeImageDataFromChunks = ({
             const yPixelOffset = yy * pixelStrides.y + zPixelOffset;
             for (let xx = itStart.x; xx < itEnd.x; xx++) {
               pixelArray[xx * pixelStrides.x + yPixelOffset] = getChunkElement(
-                (xx - x * chunkSize.x) * chunkStrides.x + yChunkOffset
+                (xx - x * chunkSize.x) * chunkStrides.x + yChunkOffset,
               );
             } // column
           } // row
@@ -179,7 +179,7 @@ registerWebworker().operation('imageDataFromChunks', async (chunkInfo) => {
     ? (
         await computeRanges(
           pixelArray,
-          chunkInfo.scaleInfo.arrayShape.get('c') ?? 1
+          chunkInfo.scaleInfo.arrayShape.get('c') ?? 1,
         )
       ).map(({ min, max }) => [min, max])
     : undefined;

--- a/packages/io/src/MultiscaleSpatialImage.cy.ts
+++ b/packages/io/src/MultiscaleSpatialImage.cy.ts
@@ -132,8 +132,8 @@ describe(`MultiscaleSpatialImage`, () => {
       return cy
         .wrap(
           ZarrMultiscaleSpatialImage.fromUrl(
-            new URL(path, document.location.origin)
-          )
+            new URL(path, document.location.origin),
+          ),
         )
         .then((zarrImage) => {
           return zarrImage.getImage(zarrImage.scaleInfos.length - 1, bounds);

--- a/packages/io/src/ZarrMultiscaleSpatialImage.ts
+++ b/packages/io/src/ZarrMultiscaleSpatialImage.ts
@@ -34,7 +34,7 @@ const TCZYX = Object.freeze([
 
 const composeTransforms = (
   transforms: Array<Transform> = [],
-  dimCount: number
+  dimCount: number,
 ) =>
   transforms.reduce(
     ({ scale, translation }, transform) => {
@@ -56,12 +56,12 @@ const composeTransforms = (
       const _exhaustiveCheck: never = transform;
       throw new Error(`unknown transform type ${_exhaustiveCheck}`);
     },
-    { scale: Array(dimCount).fill(1), translation: Array(dimCount).fill(0) }
+    { scale: Array(dimCount).fill(1), translation: Array(dimCount).fill(0) },
   );
 
 const getComposedTransformation = (
   image: NgffImage | Dataset,
-  dimCount: number
+  dimCount: number,
 ) => {
   const coordinateTransformations =
     'coordinateTransformations' in image ? image.coordinateTransformations : [];
@@ -71,7 +71,7 @@ const getComposedTransformation = (
 export const computeTransform = (
   imageMetadata: NgffImage,
   datasetMetadata: Dataset,
-  dimCount: number
+  dimCount: number,
 ) => {
   const global = getComposedTransformation(imageMetadata, dimCount);
   const dataset = getComposedTransformation(datasetMetadata, dimCount);
@@ -83,7 +83,7 @@ export const computeTransform = (
       { type: 'scale', scale: global.scale },
       { type: 'translation', translation: global.translation },
     ],
-    dimCount
+    dimCount,
   );
 };
 
@@ -92,10 +92,10 @@ const ensureScaleTransforms = (
   datasetsWithArrayMetadata: Array<{
     dataset: Dataset;
     pixelArrayMetadata: ZArray;
-  }>
+  }>,
 ) => {
   const hasDatasetCoordinateTransform = datasetsWithArrayMetadata.some(
-    ({ dataset }) => 'coordinateTransformations' in dataset
+    ({ dataset }) => 'coordinateTransformations' in dataset,
   );
   if (hasDatasetCoordinateTransform) return datasetsWithArrayMetadata;
 
@@ -128,7 +128,7 @@ const makeCoords = ({
 }) => {
   const axes = getAxisNames(multiscaleImage);
   const coords = new Map(
-    axes.map((dim) => [dim, undefined as Float32Array | undefined])
+    axes.map((dim) => [dim, undefined as Float32Array | undefined]),
   );
 
   const { scale: spacingDataset, translation: originDataset } =
@@ -167,17 +167,17 @@ const findAxesLongNames = async ({
   const upOneLevel = dataset.path.split('/').slice(0, -1).join('');
   return new Map(
     await Promise.all(
-      dims.map((dim) => dataSource.getItem(`${upOneLevel}/${dim}/.zattrs`))
+      dims.map((dim) => dataSource.getItem(`${upOneLevel}/${dim}/.zattrs`)),
     ).then((dimensionsZattrs) =>
-      dimensionsZattrs.map(({ long_name }, i) => [dims[i], long_name])
-    )
+      dimensionsZattrs.map(({ long_name }, i) => [dims[i], long_name]),
+    ),
   );
 };
 
 const getAxisNames = (image: NgffImage) => {
   if ('axes' in image)
     return image.axes.map((axis) =>
-      typeof axis === 'object' ? axis.name : axis
+      typeof axis === 'object' ? axis.name : axis,
     );
 
   return TCZYX; // default to TCZYX for NGFF v0.1
@@ -226,7 +226,7 @@ const createScaledImageInfo = async ({
     chunkCount: toDimensionMap(
       dims,
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      dims.map((dim) => Math.ceil(arrayShape.get(dim)! / chunkSize.get(dim)!))
+      dims.map((dim) => Math.ceil(arrayShape.get(dim)! / chunkSize.get(dim)!)),
     ),
     chunkSize,
     arrayShape,
@@ -252,13 +252,13 @@ const extractScaleSpacing = async (dataSource: ZarrStoreParser) => {
     multiscaleImage.datasets.map(async (dataset) => ({
       dataset,
       pixelArrayMetadata: zArray.parse(
-        await dataSource.getItem(`${dataset.path}/.zarray`)
+        await dataSource.getItem(`${dataset.path}/.zarray`),
       ) as ZArray,
-    }))
+    })),
   );
 
   const datasetsWithArrayMetadata = ensureScaleTransforms(
-    datasetsWithArrayMetadataRaw
+    datasetsWithArrayMetadataRaw,
   );
 
   const scaleInfo = await Promise.all(
@@ -270,7 +270,7 @@ const extractScaleSpacing = async (dataSource: ZarrStoreParser) => {
         dataSource,
         multiscaleSpatialImageVersion,
       });
-    })
+    }),
   );
 
   const info = scaleInfo[0];
@@ -295,7 +295,7 @@ export class ZarrMultiscaleSpatialImage extends MultiscaleSpatialImage {
   // Store parameter is object with getItem (but not a ZarrStoreParser)
   static async fromStore(
     store: HttpStore,
-    maxConcurrency: number | undefined = undefined
+    maxConcurrency: number | undefined = undefined,
   ) {
     const zarrStoreParser = new ZarrStoreParser(store);
     const { scaleInfo, imageType } = await extractScaleSpacing(zarrStoreParser);
@@ -303,17 +303,17 @@ export class ZarrMultiscaleSpatialImage extends MultiscaleSpatialImage {
       zarrStoreParser,
       scaleInfo,
       imageType,
-      maxConcurrency
+      maxConcurrency,
     );
   }
 
   static async fromUrl(
     url: URL,
-    maxConcurrency: number | undefined = undefined
+    maxConcurrency: number | undefined = undefined,
   ) {
     return ZarrMultiscaleSpatialImage.fromStore(
       new HttpStore(url),
-      maxConcurrency
+      maxConcurrency,
     );
   }
 
@@ -325,14 +325,14 @@ export class ZarrMultiscaleSpatialImage extends MultiscaleSpatialImage {
     zarrStoreParser: ZarrStoreParser,
     scaleInfos: Array<ScaleInfo>,
     imageType: ImageType,
-    maxConcurrency: number | undefined = undefined
+    maxConcurrency: number | undefined = undefined,
   ) {
     super(scaleInfos, imageType);
     this.dataSource = zarrStoreParser;
 
     const concurrency = Math.min(
       window.navigator.hardwareConcurrency,
-      maxConcurrency ?? MAX_CONCURRENCY
+      maxConcurrency ?? MAX_CONCURRENCY,
     );
     this.rpcQueue = new PQueue({ concurrency });
   }

--- a/packages/io/src/ZarrStoreParser.ts
+++ b/packages/io/src/ZarrStoreParser.ts
@@ -4,7 +4,7 @@ interface Store {
 
 const isMetadata = (item: string) =>
   ['.zattrs', '.zgroup', '.zarray'].some((knownMetadataFile) =>
-    item.endsWith(knownMetadataFile)
+    item.endsWith(knownMetadataFile),
   );
 
 export class ZarrStoreParser implements Store {

--- a/packages/io/src/analyze/UpdateHistogram.worker.js
+++ b/packages/io/src/analyze/UpdateHistogram.worker.js
@@ -19,13 +19,13 @@ registerWebworker().operation(
     const len = values.length;
     for (let i = offset; i < len; i += step) {
       const idx = Math.floor(
-        ((numberOfBins - 1) * (Number(values[i]) - min)) / delta
+        ((numberOfBins - 1) * (Number(values[i]) - min)) / delta,
       );
       histogram[idx] += 1;
     }
 
     return Promise.resolve(
-      new registerWebworker.TransferableResponse(histogram, [histogram.buffer])
+      new registerWebworker.TransferableResponse(histogram, [histogram.buffer]),
     );
-  }
+  },
 );

--- a/packages/io/src/analyze/computeRanges.js
+++ b/packages/io/src/analyze/computeRanges.js
@@ -14,7 +14,7 @@ const computeRangeWorkerPool = webWorkerPromiseWorkerPool(
     new Worker(new URL('./ComputeRanges.worker.js', import.meta.url), {
       type: 'module',
     }),
-  'computeRanges'
+  'computeRanges',
 );
 
 export async function computeRanges(values, numberOfComponents = 1) {

--- a/packages/io/src/analyze/webWorkerPromiseWorkerPool.js
+++ b/packages/io/src/analyze/webWorkerPromiseWorkerPool.js
@@ -5,7 +5,7 @@ import WebworkerPromise from 'webworker-promise';
 function webWorkerPromiseWorkerPool(
   numberOfWorkers,
   makeWorker,
-  operationName
+  operationName,
 ) {
   const createWorker = (existingWorker) => {
     if (existingWorker) {

--- a/packages/io/src/componentTypeToTypedArray.ts
+++ b/packages/io/src/componentTypeToTypedArray.ts
@@ -14,7 +14,7 @@ const componentTypeToTypedArray = new Map<componentType, TypedArrayConstructor>(
     [IntTypes.UInt32, Uint32Array],
     [FloatTypes.Float32, Float32Array],
     [FloatTypes.Float64, Float64Array],
-  ]
+  ],
 );
 
 export default componentTypeToTypedArray;

--- a/packages/io/src/dimensionUtils.ts
+++ b/packages/io/src/dimensionUtils.ts
@@ -5,16 +5,16 @@ export const CXYZT = Object.freeze(['c', 'x', 'y', 'z', 't'] as const); // viewe
 export const ensuredDims = <T>(
   defaultValue: T,
   ensuredDims: ReadonlyArray<Dimension>,
-  dimMap: ReadonlyMap<Dimension, T>
+  dimMap: ReadonlyMap<Dimension, T>,
 ) =>
   ensuredDims.reduce(
     (map, dim) => map.set(dim, map.get(dim) ?? defaultValue),
-    new Map(dimMap)
+    new Map(dimMap),
   );
 
 export const toDimensionMap = <T>(
   dims: ReadonlyArray<Dimension>,
-  array: Array<T>
+  array: Array<T>,
 ) => new Map(dims.map((dim, i) => [dim, array[i]]));
 
 // example: orderBy(['y', 'x'])(new Map([['x', 1], ['y', 2], ['z', 3]])) -> Map([['y', 2], ['x', 1]])
@@ -27,7 +27,7 @@ export const orderBy =
         const value = map.get(dim);
         if (!value) throw new Error(`Dimension ${dim} not found in map ${map}`);
         return [dim, value];
-      })
+      }),
     );
 
 export const chunkArray = <T>(chunkSize: number, array: Array<T>) => {

--- a/packages/io/src/makePlaceholderMultiscaleImage.ts
+++ b/packages/io/src/makePlaceholderMultiscaleImage.ts
@@ -1,0 +1,52 @@
+import { IntTypes, PixelTypes } from 'itk-wasm';
+
+import MultiscaleSpatialImage from './MultiscaleSpatialImage.js';
+import { Dimension } from './types.js';
+
+const makeScaleInfo = (image: string) => {
+  return {
+    dims: ['x', 'y', 'z'] as ReadonlyArray<Dimension>,
+    pixelArrayMetadata: {
+      shape: [-1],
+      chunks: [-1],
+      dtype: 'uint8',
+      compressor: {
+        cname: 'raw',
+        blocksize: -1,
+        clevel: -1,
+        shuffle: -1,
+      },
+    },
+    name: image,
+    pixelArrayPath: '',
+    coords: new Map(),
+    ranges: [[-1, 0]],
+    direction: [],
+    axesNames: [],
+    chunkCount: new Map(),
+    chunkSize: new Map(),
+    arrayShape: new Map(),
+  };
+};
+
+export const makePlaceholderMultiscaleImage = (
+  name: string,
+  scaleCount: number,
+) => {
+  const scaleInfos = Array.from({ length: scaleCount }, () =>
+    makeScaleInfo(name),
+  );
+  const imageType = {
+    dimension: 2,
+    componentType: IntTypes.UInt8,
+    pixelType: PixelTypes.Scalar,
+    components: 0,
+  };
+
+  const multiscaleImage = new MultiscaleSpatialImage(
+    scaleInfos,
+    imageType,
+    name,
+  );
+  return multiscaleImage;
+};

--- a/packages/io/src/ngff-validator.ts
+++ b/packages/io/src/ngff-validator.ts
@@ -58,14 +58,14 @@ export const image = {
                 z.object({
                   path: z.string(),
                   coordinateTransformations: coordinateTransformations,
-                })
+                }),
               )
               .min(1),
             version: z.enum(['0.4']).optional(),
             axes: z.array(axis).min(2).max(5),
             coordinateTransformations: coordinateTransformations.optional(),
             ...customNgffProperties,
-          })
+          }),
         )
         .min(1)
         .describe('The multiscale datasets for this image'),
@@ -83,7 +83,7 @@ export const image = {
               family: z.string().optional(),
               color: z.string(),
               active: z.boolean().optional(),
-            })
+            }),
           ),
         })
         .optional(),
@@ -104,7 +104,7 @@ export const image = {
               })
               .optional(),
             ...customNgffProperties,
-          })
+          }),
         )
         .min(1)
         .describe('The multiscale datasets for this image'),
@@ -122,7 +122,7 @@ export const image = {
               family: z.string().optional(),
               color: z.string(),
               active: z.boolean().optional(),
-            })
+            }),
           ),
         })
         .optional(),

--- a/packages/io/src/transformBounds.ts
+++ b/packages/io/src/transformBounds.ts
@@ -24,7 +24,7 @@ function computeCornerPoints(bounds: Bounds, point1: Vector3, point2: Vector3) {
 function computeBoundsFromPoints(
   point1: Array<number>,
   point2: vec3,
-  bounds: Bounds
+  bounds: Bounds,
 ): Bounds {
   bounds[0] = Math.min(point1[0], point2[0]);
   bounds[1] = Math.max(point1[0], point2[0]);
@@ -37,7 +37,7 @@ function computeBoundsFromPoints(
 
 export const transformBounds = (
   transformingMat4: ReadonlyMat4,
-  bounds: Bounds
+  bounds: Bounds,
 ) => {
   const in1: Vector3 = Array(3) as Vector3;
   const in2: Vector3 = Array(3) as Vector3;

--- a/packages/remote-viewport/package.json
+++ b/packages/remote-viewport/package.json
@@ -21,13 +21,14 @@
   },
   "homepage": "https://github.com/InsightSoftwareConsortium/itk-viewer#readme",
   "devDependencies": {
-    "typescript": "^5.1.3",
-    "vite": "^4.3.9"
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
   },
   "dependencies": {
     "@itk-viewer/viewer": "workspace:^",
     "@itk-wasm/htj2k": "^1.0.0",
-    "imjoy-rpc": "^0.5.42",
-    "xstate": "5.0.0-beta.18"
+    "gl-matrix": "^3.4.3",
+    "imjoy-rpc": "^0.5.44",
+    "xstate": "5.0.0-beta.24"
   }
 }

--- a/packages/remote-viewport/package.json
+++ b/packages/remote-viewport/package.json
@@ -25,6 +25,7 @@
     "vite": "^4.4.9"
   },
   "dependencies": {
+    "@itk-viewer/io": "workspace:^",
     "@itk-viewer/viewer": "workspace:^",
     "@itk-wasm/htj2k": "^1.0.0",
     "gl-matrix": "^3.4.3",

--- a/packages/remote-viewport/src/remote-machine.ts
+++ b/packages/remote-viewport/src/remote-machine.ts
@@ -188,7 +188,6 @@ export const remoteMachine = createMachine(
                 invoke: {
                   id: 'fpsWatcher',
                   src: fpsWatcher,
-                  onSnapshot: { actions: (e) => console.log('slow', e) },
                 },
               },
               renderLoop: {
@@ -215,6 +214,11 @@ export const remoteMachine = createMachine(
                           })),
                         ],
                         target: 'idle',
+                      },
+                      onError: {
+                        actions: (e) =>
+                          console.error('Error while updating render', e),
+                        target: 'idle', // soldier on
                       },
                     },
                   },

--- a/packages/remote-viewport/src/remote-machine.ts
+++ b/packages/remote-viewport/src/remote-machine.ts
@@ -265,5 +265,5 @@ export const remoteMachine = createMachine(
         }
       },
     },
-  }
+  },
 );

--- a/packages/remote-viewport/src/remote-viewport.ts
+++ b/packages/remote-viewport/src/remote-viewport.ts
@@ -3,7 +3,6 @@ import { hyphaWebsocketClient } from 'imjoy-rpc';
 import { mat4, vec3 } from 'gl-matrix';
 //@ts-expect-error .d.ts file not resolved
 import { decode } from '@itk-wasm/htj2k';
-import { Viewport, createViewport } from '@itk-viewer/viewer/viewport.js';
 import { RendererEntries, remoteMachine, Context } from './remote-machine.js';
 import { RenderedFrame } from './types.js';
 
@@ -21,10 +20,8 @@ type RendererInput = {
 type ConnectInput = { context: Context };
 
 export type RemoteMachineActors = {
-  actors: {
-    connect: ReturnType<typeof fromPromise<unknown, ConnectInput>>;
-    renderer: ReturnType<typeof fromPromise<RenderedFrame, RendererInput>>;
-  };
+  connect: ReturnType<typeof fromPromise<unknown, ConnectInput>>;
+  renderer: ReturnType<typeof fromPromise<RenderedFrame, RendererInput>>;
 };
 
 type HyphaServiceConfig = {
@@ -54,75 +51,67 @@ export const createHyphaActors: () => RemoteMachineActors = () => {
   let decodeWorker: Worker | null = null;
 
   return {
-    actors: {
-      connect: fromPromise(async ({ input }: { input: ConnectInput }) =>
-        createHyphaRenderer(input.context)
-      ),
-      renderer: fromPromise(
-        async ({ input: { server, events } }: { input: RendererInput }) => {
-          const translatedEvents = events
-            .map(([key, value]) => {
-              if (key === 'cameraPose') {
-                const eye = vec3.create();
-                mat4.getTranslation(eye, value);
+    connect: fromPromise(async ({ input }: { input: ConnectInput }) =>
+      createHyphaRenderer(input.context),
+    ),
+    renderer: fromPromise(
+      async ({ input: { server, events } }: { input: RendererInput }) => {
+        const translatedEvents = events
+          .map(([key, value]) => {
+            if (key === 'cameraPose') {
+              const eye = vec3.create();
+              mat4.getTranslation(eye, value);
 
-                const target = vec3.fromValues(value[8], value[9], value[10]);
-                vec3.subtract(target, eye, target);
+              const target = vec3.fromValues(value[8], value[9], value[10]);
+              vec3.subtract(target, eye, target);
 
-                const up = vec3.fromValues(value[4], value[5], value[6]);
+              const up = vec3.fromValues(value[4], value[5], value[6]);
 
-                return ['cameraPose', { eye, up, target }];
-              }
+              return ['cameraPose', { eye, up, target }];
+            }
 
-              if (key === 'image') {
-                server.loadImage(value);
-                return;
-              }
+            if (key === 'image') {
+              console.log('loading image', value);
+              server.loadImage(value);
+              return;
+            }
 
-              return [key, value];
-            })
-            .filter(Boolean);
+            return [key, value];
+          })
+          .filter(Boolean);
 
-          server.updateRenderer(translatedEvents);
-          const { frame: encodedImage, renderTime } = await server.render();
-          const { image: frame, webWorker } = await decode(
-            decodeWorker,
-            encodedImage
-          );
-          decodeWorker = webWorker;
+        server.updateRenderer(translatedEvents);
+        const { frame: encodedImage, renderTime } = await server.render();
+        const { image: frame, webWorker } = await decode(
+          decodeWorker,
+          encodedImage,
+        );
+        decodeWorker = webWorker;
 
-          return { frame, renderTime };
-        }
-      ),
-    },
+        return { frame, renderTime };
+      },
+    ),
   };
 };
 
 export type RemoteMachineOptions = {
-  context: {
-    viewport: Viewport;
-  };
-} & RemoteMachineActors;
+  actors: RemoteMachineActors;
+};
 
 const createRemote = (config: RemoteMachineOptions) => {
   const remoteActor = remoteMachine.provide(config);
 
-  return createActor(remoteActor, {
-    input: config.context,
-  }).start();
+  return createActor(remoteActor).start();
 };
 
 export type RemoteActor = ReturnType<typeof createRemote>;
 
-export const createRemoteViewport = (config: RemoteMachineActors) => {
-  const viewport = createViewport();
-  const configWithViewport = {
-    ...config,
-    context: {
-      viewport,
-    },
+export const createRemoteViewport = (actors: RemoteMachineActors) => {
+  const config = {
+    actors,
   };
-  const remote = createRemote(configWithViewport);
+  const remote = createRemote(config);
+  const viewport = remote.getSnapshot().context.viewport;
 
   return { remote, viewport };
 };

--- a/packages/viewer/index.html
+++ b/packages/viewer/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -41,12 +41,12 @@
   },
   "homepage": "https://github.com/InsightSoftwareConsortium/itk-viewer#readme",
   "devDependencies": {
-    "typescript": "^5.1.3",
-    "vite": "^4.3.9"
+    "typescript": "^5.2.2",
+    "vite": "^4.4.9"
   },
   "dependencies": {
     "@itk-viewer/io": "workspace:^",
     "gl-matrix": "^3.4.3",
-    "xstate": "5.0.0-beta.18"
+    "xstate": "5.0.0-beta.24"
   }
 }

--- a/packages/viewer/src/camera-machine.ts
+++ b/packages/viewer/src/camera-machine.ts
@@ -1,5 +1,5 @@
 import { ReadonlyMat4, mat4 } from 'gl-matrix';
-import { assign, createActor, createMachine, } from 'xstate';
+import { assign, createActor, createMachine } from 'xstate';
 
 type context = {
   pose: ReadonlyMat4;

--- a/packages/viewer/src/camera-machine.ts
+++ b/packages/viewer/src/camera-machine.ts
@@ -1,5 +1,5 @@
 import { ReadonlyMat4, mat4 } from 'gl-matrix';
-import { assign, createMachine, interpret } from 'xstate';
+import { assign, createActor, createMachine, } from 'xstate';
 
 type context = {
   pose: ReadonlyMat4;
@@ -34,7 +34,7 @@ const cameraMachine = createMachine({
 });
 
 export const createCamera = () => {
-  return interpret(cameraMachine).start();
+  return createActor(cameraMachine).start();
 };
 
 export type Camera = ReturnType<typeof createCamera>;

--- a/packages/viewer/src/fps-watcher-machine.ts
+++ b/packages/viewer/src/fps-watcher-machine.ts
@@ -73,5 +73,5 @@ export const fpsWatcher = createMachine(
       checkSlow: ({ context: { average } }) => average < SLOW_FRAME_TIME,
       checkFast: ({ context: { average } }) => average > FAST_FRAME_TIME,
     },
-  }
+  },
 );

--- a/packages/viewer/src/viewer-machine.ts
+++ b/packages/viewer/src/viewer-machine.ts
@@ -1,12 +1,14 @@
-import { assign, createMachine } from 'xstate';
+import { ActorRefFrom, assign, createMachine } from 'xstate';
 
 import MultiscaleSpatialImage from '@itk-viewer/io/MultiscaleSpatialImage.js';
-import { Viewport } from './viewport.js';
+import { viewportMachine } from './viewport-machine.js';
+
+type ViewportActor = ActorRefFrom<typeof viewportMachine>;
 
 type addViewportEvent = {
   type: 'addViewport';
   name: string;
-  viewport: Viewport;
+  viewport: ViewportActor;
 };
 
 type addImageEvent = {
@@ -16,7 +18,7 @@ type addImageEvent = {
 };
 
 type context = {
-  viewports: Record<string, Viewport>;
+  viewports: Record<string, ViewportActor>;
   images: Record<string, MultiscaleSpatialImage>;
 };
 

--- a/packages/viewer/src/viewer.cy.ts
+++ b/packages/viewer/src/viewer.cy.ts
@@ -17,7 +17,7 @@ describe('Viewer', () => {
     cy.wrap(viewer.getSnapshot().context.viewports).should(
       'have.property',
       'first',
-      viewport
+      viewport,
     );
   });
 
@@ -34,7 +34,7 @@ describe('Viewer', () => {
 
     const storeURL = new URL(
       '/ome-ngff-prototypes/single_image/v0.4/yx.ome.zarr',
-      document.location.origin
+      document.location.origin,
     );
     const image = await ZarrMultiscaleSpatialImage.fromUrl(storeURL);
     viewer.send({ type: 'addImage', name: 'zarr', image });

--- a/packages/viewer/src/viewer.ts
+++ b/packages/viewer/src/viewer.ts
@@ -1,9 +1,9 @@
-import { interpret } from 'xstate';
+import { createActor } from 'xstate';
 
 import { viewerMachine } from './viewer-machine.js';
 
 export const createViewer = () => {
-  return interpret(viewerMachine).start();
+  return createActor(viewerMachine).start();
 };
 
 export type Viewer = ReturnType<typeof createViewer>;

--- a/packages/viewer/src/viewport-machine.ts
+++ b/packages/viewer/src/viewport-machine.ts
@@ -1,4 +1,4 @@
-import { ActorRef, assign, createMachine } from 'xstate';
+import { ActorRef, assign, createMachine, sendParent } from 'xstate';
 
 import MultiscaleSpatialImage from '@itk-viewer/io/MultiscaleSpatialImage.js';
 import { Camera } from './camera-machine.js';
@@ -45,6 +45,9 @@ export const viewportMachine = createMachine({
             assign({
               image: ({ event: { image } }: { event: SetImageEvent }) => image,
             }),
+            sendParent(({ event }) => {
+              return event;
+            }),
           ],
         },
         setCamera: {
@@ -66,9 +69,16 @@ export const viewportMachine = createMachine({
                     type: 'cameraPoseUpdated',
                     pose: cameraState.context.pose,
                   });
-                }
+                },
               );
             },
+          ],
+        },
+        cameraPoseUpdated: {
+          actions: [
+            sendParent(({ event }) => {
+              return event;
+            }),
           ],
         },
       },

--- a/packages/viewer/src/viewport.cy.ts
+++ b/packages/viewer/src/viewport.cy.ts
@@ -14,7 +14,7 @@ describe('Viewport', () => {
 
     const storeURL = new URL(
       '/ome-ngff-prototypes/single_image/v0.4/yx.ome.zarr',
-      document.location.origin
+      document.location.origin,
     );
     const image = await ZarrMultiscaleSpatialImage.fromUrl(storeURL);
 
@@ -31,7 +31,7 @@ describe('Viewport', () => {
     viewport.send({ type: 'setCamera', camera });
 
     cy.wrap(
-      viewport.getSnapshot().context.camera?.getSnapshot().context.pose
+      viewport.getSnapshot().context.camera?.getSnapshot().context.pose,
     ).should('deep.equal', camera.getSnapshot().context.pose);
 
     let cameraPose = undefined;

--- a/packages/viewer/src/viewport.ts
+++ b/packages/viewer/src/viewport.ts
@@ -1,8 +1,15 @@
 import { createActor } from 'xstate';
 import { viewportMachine } from './viewport-machine.js';
 
+const noop = () => {};
+
 export const createViewport = () => {
-  return createActor(viewportMachine).start();
+  const standAloneViewportLogic = viewportMachine.provide({
+    actions: {
+      forwardToParent: noop, // if not spawned in system, don't error
+    },
+  });
+  return createActor(standAloneViewportLogic).start();
 };
 
 export type Viewport = ReturnType<typeof createViewport>;

--- a/packages/viewer/src/viewport.ts
+++ b/packages/viewer/src/viewport.ts
@@ -1,8 +1,8 @@
-import { interpret } from 'xstate';
+import { createActor } from 'xstate';
 import { viewportMachine } from './viewport-machine.js';
 
 export const createViewport = () => {
-  return interpret(viewportMachine).start();
+  return createActor(viewportMachine).start();
 };
 
 export type Viewport = ReturnType<typeof createViewport>;

--- a/packages/wasm-utils/package.json
+++ b/packages/wasm-utils/package.json
@@ -41,10 +41,10 @@
   },
   "homepage": "https://github.com/InsightSoftwareConsortium/itk-viewer#readme",
   "devDependencies": {
-    "typescript": "^4.8.4"
+    "typescript": "^5.2.2"
   },
   "dependencies": {
-    "itk-wasm": "1.0.0-b.112"
+    "itk-wasm": "1.0.0-b.133"
   },
   "eslintConfig": {
     "env": {

--- a/packages/wasm-utils/src/dtypeUtils.js
+++ b/packages/wasm-utils/src/dtypeUtils.js
@@ -26,11 +26,11 @@ const dtypeUtils = Array.from(
 
     ['f4', [Float32Array, 'getFloat32', FloatTypes.Float32]],
     ['f8', [Float64Array, 'getFloat64', FloatTypes.Float64]],
-  ])
+  ]),
 ).reduce(
   (map, [dtype, [TypedArray, dataViewGetter, itkComponent]]) =>
     map.set(dtype, { TypedArray, dataViewGetter, itkComponent }),
-  new Map()
+  new Map(),
 );
 
 const getType = (dtype) => dtype.replace(/^(<|>|=|\|)/, ''); // remove starting < > = | endianness
@@ -59,7 +59,7 @@ export const ElementGetter = (dtype, buffer) => {
 
 export const getDtype = (typedArrayConstructor, endianness = '<') => {
   const typedArrayToDtype = new Map(
-    Array.from(dtypeUtils).map(([key, { TypedArray }]) => [TypedArray, key])
+    Array.from(dtypeUtils).map(([key, { TypedArray }]) => [TypedArray, key]),
   );
   return `${endianness}${typedArrayToDtype.get(typedArrayConstructor)}`;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
 
   packages/remote-viewport:
     dependencies:
+      '@itk-viewer/io':
+        specifier: workspace:^
+        version: link:../io
       '@itk-viewer/viewer':
         specifier: workspace:^
         version: link:../viewer

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,12 @@ importers:
       orbit-camera:
         specifier: ^1.0.0
         version: 1.0.0
+      xstate:
+        specifier: 5.0.0-beta.24
+        version: 5.0.0-beta.24
       xstate-lit:
         specifier: ^1.3.1
-        version: 1.3.1(lit@2.8.0)(xstate@4.38.2)
+        version: 1.3.1(lit@2.8.0)(xstate@5.0.0-beta.24)
     devDependencies:
       typescript:
         specifier: ^5.2.2
@@ -4486,7 +4489,7 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: false
 
-  /xstate-lit@1.3.1(lit@2.8.0)(xstate@4.38.2):
+  /xstate-lit@1.3.1(lit@2.8.0)(xstate@5.0.0-beta.24):
     resolution: {integrity: sha512-p/HiJLTSVtPYV81MzeEe8WDe4cP/Rqc4b9KgeRIN5CTyf/76TspzWYAYCjUJiEHojJGGO8lo0d8IqjO+iIrr/g==}
     peerDependencies:
       '@lit-labs/context': ^0.2.0
@@ -4497,11 +4500,7 @@ packages:
         optional: true
     dependencies:
       lit: 2.8.0
-      xstate: 4.38.2
-    dev: false
-
-  /xstate@4.38.2:
-    resolution: {integrity: sha512-Fba/DwEPDLneHT3tbJ9F3zafbQXszOlyCJyQqqdzmtlY/cwE2th462KK48yaANf98jHlP6lJvxfNtN0LFKXPQg==}
+      xstate: 5.0.0-beta.24
     dev: false
 
   /xstate@5.0.0-beta.24:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,41 +15,41 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       '@typescript-eslint/eslint-plugin':
-        specifier: ^5.59.8
-        version: 5.59.8(@typescript-eslint/parser@5.59.8)(eslint@8.41.0)(typescript@5.1.3)
+        specifier: ^6.5.0
+        version: 6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.48.0)(typescript@5.2.2)
       '@typescript-eslint/parser':
-        specifier: ^5.59.8
-        version: 5.59.8(eslint@8.41.0)(typescript@5.1.3)
+        specifier: ^6.5.0
+        version: 6.5.0(eslint@8.48.0)(typescript@5.2.2)
       cypress:
-        specifier: ^12.13.0
-        version: 12.13.0
+        specifier: ^13.0.0
+        version: 13.0.0
       cypress-lit:
-        specifier: ^0.0.7
-        version: 0.0.7(cypress@12.13.0)
+        specifier: ^0.0.8
+        version: 0.0.8(cypress@13.0.0)
       eslint:
-        specifier: ^8.41.0
-        version: 8.41.0
+        specifier: ^8.48.0
+        version: 8.48.0
       follow-redirects:
         specifier: ^1.15.2
         version: 1.15.2
       lit:
-        specifier: ^2.7.5
-        version: 2.7.5
+        specifier: ^2.8.0
+        version: 2.8.0
       prettier:
-        specifier: ^2.8.8
-        version: 2.8.8
+        specifier: ^3.0.3
+        version: 3.0.3
       tar:
         specifier: ^6.1.15
         version: 6.1.15
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.3
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9
+        specifier: ^4.4.9
+        version: 4.4.9
       vite-plugin-static-copy:
-        specifier: ^0.15.0
-        version: 0.15.0(vite@4.3.9)
+        specifier: ^0.17.0
+        version: 0.17.0(vite@4.4.9)
 
   packages/blosc-zarr:
     dependencies:
@@ -57,12 +57,12 @@ importers:
         specifier: workspace:^
         version: link:../wasm-utils
       itk-wasm:
-        specifier: 1.0.0-b.112
-        version: 1.0.0-b.112
+        specifier: 1.0.0-b.133
+        version: 1.0.0-b.133
     devDependencies:
       typescript:
-        specifier: ^4.8.4
-        version: 4.8.4
+        specifier: ^5.2.2
+        version: 5.2.2
 
   packages/element:
     dependencies:
@@ -79,21 +79,21 @@ importers:
         specifier: ^3.4.3
         version: 3.4.3
       lit:
-        specifier: ^2.7.4
-        version: 2.7.4
+        specifier: ^2.8.0
+        version: 2.8.0
       orbit-camera:
         specifier: ^1.0.0
         version: 1.0.0
       xstate-lit:
         specifier: ^1.3.1
-        version: 1.3.1(lit@2.7.4)(xstate@4.38.2)
+        version: 1.3.1(lit@2.8.0)(xstate@4.38.2)
     devDependencies:
       typescript:
-        specifier: ^5.0.4
-        version: 5.0.4
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9
+        specifier: ^4.4.9
+        version: 4.4.9
 
   packages/io:
     dependencies:
@@ -104,14 +104,14 @@ importers:
         specifier: workspace:^
         version: link:../wasm-utils
       axios:
-        specifier: ^1.4.0
-        version: 1.4.0
+        specifier: ^1.5.0
+        version: 1.5.0
       gl-matrix:
         specifier: ^3.4.3
         version: 3.4.3
       itk-wasm:
-        specifier: 1.0.0-b.112
-        version: 1.0.0-b.112
+        specifier: 1.0.0-b.133
+        version: 1.0.0-b.133
       p-queue:
         specifier: ^7.3.4
         version: 7.3.4
@@ -119,12 +119,12 @@ importers:
         specifier: ^0.5.1
         version: 0.5.1
       zod:
-        specifier: ^3.21.4
-        version: 3.21.4
+        specifier: ^3.22.2
+        version: 3.22.2
     devDependencies:
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.3
+        specifier: ^5.2.2
+        version: 5.2.2
 
   packages/remote-viewport:
     dependencies:
@@ -134,19 +134,22 @@ importers:
       '@itk-wasm/htj2k':
         specifier: ^1.0.0
         version: 1.0.0
+      gl-matrix:
+        specifier: ^3.4.3
+        version: 3.4.3
       imjoy-rpc:
-        specifier: ^0.5.42
-        version: 0.5.42
+        specifier: ^0.5.44
+        version: 0.5.44
       xstate:
-        specifier: 5.0.0-beta.18
-        version: 5.0.0-beta.18
+        specifier: 5.0.0-beta.24
+        version: 5.0.0-beta.24
     devDependencies:
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.3
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9
+        specifier: ^4.4.9
+        version: 4.4.9
 
   packages/viewer:
     dependencies:
@@ -157,33 +160,38 @@ importers:
         specifier: ^3.4.3
         version: 3.4.3
       xstate:
-        specifier: 5.0.0-beta.18
-        version: 5.0.0-beta.18
+        specifier: 5.0.0-beta.24
+        version: 5.0.0-beta.24
     devDependencies:
       typescript:
-        specifier: ^5.1.3
-        version: 5.1.3
+        specifier: ^5.2.2
+        version: 5.2.2
       vite:
-        specifier: ^4.3.9
-        version: 4.3.9
+        specifier: ^4.4.9
+        version: 4.4.9
 
   packages/wasm-utils:
     dependencies:
       itk-wasm:
-        specifier: 1.0.0-b.112
-        version: 1.0.0-b.112
+        specifier: 1.0.0-b.133
+        version: 1.0.0-b.133
     devDependencies:
       typescript:
-        specifier: ^4.8.4
-        version: 4.8.4
+        specifier: ^5.2.2
+        version: 5.2.2
 
 packages:
 
-  /@babel/code-frame@7.22.10:
-    resolution: {integrity: sha512-/KKIMG4UEL35WmI9OlvMhurwtytjvXoFcGNrOvyG9zIzA8YmPjVtIZUf7b05+TPO7G7/GEmLHDaoCgACHl9hhA==}
+  /@aashutoshrathi/word-wrap@1.2.6:
+    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
+  /@babel/code-frame@7.22.13:
+    resolution: {integrity: sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.22.10
+      '@babel/highlight': 7.22.13
       chalk: 2.4.2
     dev: true
 
@@ -192,8 +200,8 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/highlight@7.22.10:
-    resolution: {integrity: sha512-78aUtVcT7MUscr0K5mIEnkwxPE0MaxkR5RxRwuHaQ+JuU5AmTPhY+do2mdzVTnIJJpyBglql2pehuBIWHug+WQ==}
+  /@babel/highlight@7.22.13:
+    resolution: {integrity: sha512-C/BaXcnnvBCmHTpz/VGZ8jgtE2aYlW4hxDhseJAWZb7gqGM/qtCK6iZUb0TyKFf7BOUsBH7Q7fkRsDRhg1XklQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-validator-identifier': 7.22.5
@@ -201,16 +209,16 @@ packages:
       js-tokens: 4.0.0
     dev: true
 
-  /@babel/runtime@7.22.3:
-    resolution: {integrity: sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==}
+  /@babel/runtime@7.22.11:
+    resolution: {integrity: sha512-ee7jVNlWN09+KftVOu9n7S8gQzD/Z6hN/I8VBRXW4P1+Xe7kJGXMwu8vds4aGIMHZnNbdpSWCfZZtinytpcAvA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      regenerator-runtime: 0.13.11
+      regenerator-runtime: 0.14.0
 
   /@changesets/apply-release-plan@6.1.4:
     resolution: {integrity: sha512-FMpKF1fRlJyCZVYHr3CbinpZZ+6MwvOtWUuO8uo+svcATEoc1zRDcj23pAurJ2TZ/uVz1wFHH6K3NlACy0PLew==}
     dependencies:
-      '@babel/runtime': 7.22.3
+      '@babel/runtime': 7.22.11
       '@changesets/config': 2.3.1
       '@changesets/get-version-range-type': 0.3.2
       '@changesets/git': 2.0.0
@@ -228,7 +236,7 @@ packages:
   /@changesets/assemble-release-plan@5.2.4:
     resolution: {integrity: sha512-xJkWX+1/CUaOUWTguXEbCDTyWJFECEhmdtbkjhn5GVBGxdP/JwaHBIU9sW3FR6gD07UwZ7ovpiPclQZs+j+mvg==}
     dependencies:
-      '@babel/runtime': 7.22.3
+      '@babel/runtime': 7.22.11
       '@changesets/errors': 0.1.4
       '@changesets/get-dependents-graph': 1.3.6
       '@changesets/types': 5.2.1
@@ -246,7 +254,7 @@ packages:
     resolution: {integrity: sha512-dnWrJTmRR8bCHikJHl9b9HW3gXACCehz4OasrXpMp7sx97ECuBGGNjJhjPhdZNCvMy9mn4BWdplI323IbqsRig==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.22.3
+      '@babel/runtime': 7.22.11
       '@changesets/apply-release-plan': 6.1.4
       '@changesets/assemble-release-plan': 5.2.4
       '@changesets/changelog-git': 0.1.14
@@ -262,10 +270,10 @@ packages:
       '@changesets/write': 0.2.3
       '@manypkg/get-packages': 1.1.3
       '@types/is-ci': 3.0.0
-      '@types/semver': 7.5.0
+      '@types/semver': 7.5.1
       ansi-colors: 4.1.3
       chalk: 2.4.2
-      enquirer: 2.3.6
+      enquirer: 2.4.1
       external-editor: 3.1.0
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -312,7 +320,7 @@ packages:
   /@changesets/get-release-plan@3.0.17:
     resolution: {integrity: sha512-6IwKTubNEgoOZwDontYc2x2cWXfr6IKxP3IhKeK+WjyD6y3M4Gl/jdQvBw+m/5zWILSOCAaGLu2ZF6Q+WiPniw==}
     dependencies:
-      '@babel/runtime': 7.22.3
+      '@babel/runtime': 7.22.11
       '@changesets/assemble-release-plan': 5.2.4
       '@changesets/config': 2.3.1
       '@changesets/pre': 1.0.14
@@ -328,7 +336,7 @@ packages:
   /@changesets/git@2.0.0:
     resolution: {integrity: sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==}
     dependencies:
-      '@babel/runtime': 7.22.3
+      '@babel/runtime': 7.22.11
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -353,7 +361,7 @@ packages:
   /@changesets/pre@1.0.14:
     resolution: {integrity: sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==}
     dependencies:
-      '@babel/runtime': 7.22.3
+      '@babel/runtime': 7.22.11
       '@changesets/errors': 0.1.4
       '@changesets/types': 5.2.1
       '@manypkg/get-packages': 1.1.3
@@ -363,7 +371,7 @@ packages:
   /@changesets/read@0.5.9:
     resolution: {integrity: sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==}
     dependencies:
-      '@babel/runtime': 7.22.3
+      '@babel/runtime': 7.22.11
       '@changesets/git': 2.0.0
       '@changesets/logger': 0.0.5
       '@changesets/parse': 0.3.16
@@ -384,7 +392,7 @@ packages:
   /@changesets/write@0.2.3:
     resolution: {integrity: sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==}
     dependencies:
-      '@babel/runtime': 7.22.3
+      '@babel/runtime': 7.22.11
       '@changesets/types': 5.2.1
       fs-extra: 7.0.1
       human-id: 1.0.2
@@ -402,8 +410,8 @@ packages:
     resolution: {integrity: sha512-4w8WZpOALz5+vhJmPfh2HkT4NMsRP2DgVqSXxXu46GR5yUGfqJ0+WgUrmVuujtKKY6n1mDiO1L4AfZ+4bsEYGQ==}
     dev: true
 
-  /@cypress/request@2.88.11:
-    resolution: {integrity: sha512-M83/wfQ1EkspjkE2lNWNV5ui2Cv7UCv1swW1DqljahbzLVWltcsexQh8jYtuS/vzFXP+HySntGM83ZXA9fn17w==}
+  /@cypress/request@3.0.0:
+    resolution: {integrity: sha512-GKFCqwZwMYmL3IBoNeR2MM1SnxRIGERsQOTWeQKoYBt2JLqcqiy7JXqO894FLrpjZYqGxW92MNwRH2BN56obdQ==}
     engines: {node: '>= 6'}
     dependencies:
       aws-sign2: 0.7.0
@@ -421,7 +429,7 @@ packages:
       performance-now: 2.1.0
       qs: 6.10.4
       safe-buffer: 5.2.1
-      tough-cookie: 2.5.0
+      tough-cookie: 4.1.3
       tunnel-agent: 0.6.0
       uuid: 8.3.2
     dev: true
@@ -435,8 +443,8 @@ packages:
       - supports-color
     dev: true
 
-  /@esbuild/android-arm64@0.17.19:
-    resolution: {integrity: sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==}
+  /@esbuild/android-arm64@0.18.20:
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
@@ -444,8 +452,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-arm@0.17.19:
-    resolution: {integrity: sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==}
+  /@esbuild/android-arm@0.18.20:
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [android]
@@ -453,8 +461,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/android-x64@0.17.19:
-    resolution: {integrity: sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==}
+  /@esbuild/android-x64@0.18.20:
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
@@ -462,8 +470,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-arm64@0.17.19:
-    resolution: {integrity: sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==}
+  /@esbuild/darwin-arm64@0.18.20:
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
@@ -471,8 +479,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/darwin-x64@0.17.19:
-    resolution: {integrity: sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==}
+  /@esbuild/darwin-x64@0.18.20:
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
@@ -480,8 +488,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-arm64@0.17.19:
-    resolution: {integrity: sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==}
+  /@esbuild/freebsd-arm64@0.18.20:
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
@@ -489,8 +497,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/freebsd-x64@0.17.19:
-    resolution: {integrity: sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==}
+  /@esbuild/freebsd-x64@0.18.20:
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
@@ -498,8 +506,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm64@0.17.19:
-    resolution: {integrity: sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==}
+  /@esbuild/linux-arm64@0.18.20:
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
@@ -507,8 +515,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-arm@0.17.19:
-    resolution: {integrity: sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==}
+  /@esbuild/linux-arm@0.18.20:
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
@@ -516,8 +524,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ia32@0.17.19:
-    resolution: {integrity: sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==}
+  /@esbuild/linux-ia32@0.18.20:
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
@@ -525,8 +533,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-loong64@0.17.19:
-    resolution: {integrity: sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==}
+  /@esbuild/linux-loong64@0.18.20:
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
     cpu: [loong64]
     os: [linux]
@@ -534,8 +542,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-mips64el@0.17.19:
-    resolution: {integrity: sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==}
+  /@esbuild/linux-mips64el@0.18.20:
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
@@ -543,8 +551,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-ppc64@0.17.19:
-    resolution: {integrity: sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==}
+  /@esbuild/linux-ppc64@0.18.20:
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
@@ -552,8 +560,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-riscv64@0.17.19:
-    resolution: {integrity: sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==}
+  /@esbuild/linux-riscv64@0.18.20:
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
@@ -561,8 +569,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-s390x@0.17.19:
-    resolution: {integrity: sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==}
+  /@esbuild/linux-s390x@0.18.20:
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
@@ -570,8 +578,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/linux-x64@0.17.19:
-    resolution: {integrity: sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==}
+  /@esbuild/linux-x64@0.18.20:
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
@@ -579,8 +587,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/netbsd-x64@0.17.19:
-    resolution: {integrity: sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==}
+  /@esbuild/netbsd-x64@0.18.20:
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
@@ -588,8 +596,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/openbsd-x64@0.17.19:
-    resolution: {integrity: sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==}
+  /@esbuild/openbsd-x64@0.18.20:
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
@@ -597,8 +605,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/sunos-x64@0.17.19:
-    resolution: {integrity: sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==}
+  /@esbuild/sunos-x64@0.18.20:
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
@@ -606,8 +614,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-arm64@0.17.19:
-    resolution: {integrity: sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==}
+  /@esbuild/win32-arm64@0.18.20:
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
@@ -615,8 +623,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-ia32@0.17.19:
-    resolution: {integrity: sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==}
+  /@esbuild/win32-ia32@0.18.20:
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
@@ -624,8 +632,8 @@ packages:
     dev: true
     optional: true
 
-  /@esbuild/win32-x64@0.17.19:
-    resolution: {integrity: sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==}
+  /@esbuild/win32-x64@0.18.20:
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
@@ -633,29 +641,29 @@ packages:
     dev: true
     optional: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.41.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.48.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.41.0
-      eslint-visitor-keys: 3.4.1
+      eslint: 8.48.0
+      eslint-visitor-keys: 3.4.3
     dev: true
 
-  /@eslint-community/regexpp@4.5.1:
-    resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
+  /@eslint-community/regexpp@4.8.0:
+    resolution: {integrity: sha512-JylOEEzDiOryeUnFbQz+oViCXS0KsvR1mvHkoMiu5+UiBvy+RYX7tzlIIIEstF/gVa2tj9AQXk3dgnxv6KxhFg==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
     dev: true
 
-  /@eslint/eslintrc@2.0.3:
-    resolution: {integrity: sha512-+5gy6OQfk+xx3q0d6jGZZC3f3KzAkXc/IanVxd1is/VIIziRqqt3ongQz0FiTUXqTk0c7aDB3OaFuKnuSoJicQ==}
+  /@eslint/eslintrc@2.1.2:
+    resolution: {integrity: sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
       debug: 4.3.4(supports-color@8.1.1)
-      espree: 9.5.2
-      globals: 13.20.0
+      espree: 9.6.1
+      globals: 13.21.0
       ignore: 5.2.4
       import-fresh: 3.3.0
       js-yaml: 4.1.0
@@ -665,13 +673,13 @@ packages:
       - supports-color
     dev: true
 
-  /@eslint/js@8.41.0:
-    resolution: {integrity: sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==}
+  /@eslint/js@8.48.0:
+    resolution: {integrity: sha512-ZSjtmelB7IJfWD2Fvb7+Z+ChTIKWq6kjda95fLcQKNS5aheVHn4IkfgRQE3sIIzTcSLwLcLZUD9UBt+V7+h+Pw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@humanwhocodes/config-array@0.11.10:
-    resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
+  /@humanwhocodes/config-array@0.11.11:
+    resolution: {integrity: sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -693,7 +701,7 @@ packages:
   /@itk-wasm/htj2k@1.0.0:
     resolution: {integrity: sha512-X2PCvp4momE2QMrjZKC5iWJpH2ZuxLR7K2fgvRyW/mT4vORk5ZzCd8teFaYCHePAtt5cGCOA1NelKdj4ZdgH6Q==}
     dependencies:
-      itk-wasm: 1.0.0-b.129
+      itk-wasm: 1.0.0-b.133
     transitivePeerDependencies:
       - debug
     dev: false
@@ -704,11 +712,11 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.19
     dev: false
 
-  /@jridgewell/resolve-uri@3.1.0:
-    resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
+  /@jridgewell/resolve-uri@3.1.1:
+    resolution: {integrity: sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==}
     engines: {node: '>=6.0.0'}
     dev: false
 
@@ -717,46 +725,36 @@ packages:
     engines: {node: '>=6.0.0'}
     dev: false
 
-  /@jridgewell/source-map@0.3.3:
-    resolution: {integrity: sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==}
+  /@jridgewell/source-map@0.3.5:
+    resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.18
-    dev: false
-
-  /@jridgewell/sourcemap-codec@1.4.14:
-    resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+      '@jridgewell/trace-mapping': 0.3.19
     dev: false
 
   /@jridgewell/sourcemap-codec@1.4.15:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
     dev: false
 
-  /@jridgewell/trace-mapping@0.3.18:
-    resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
+  /@jridgewell/trace-mapping@0.3.19:
+    resolution: {integrity: sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==}
     dependencies:
-      '@jridgewell/resolve-uri': 3.1.0
-      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/resolve-uri': 3.1.1
+      '@jridgewell/sourcemap-codec': 1.4.15
     dev: false
 
   /@lit-labs/ssr-dom-shim@1.1.1:
     resolution: {integrity: sha512-kXOeFbfCm4fFf2A3WwVEeQj55tMZa8c8/f9AKHMobQMkzNUfUj+antR3fRPaZJawsa1aZiP/Da3ndpZrwEe4rQ==}
 
-  /@lit/reactive-element@1.6.1:
-    resolution: {integrity: sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==}
-    dependencies:
-      '@lit-labs/ssr-dom-shim': 1.1.1
-    dev: false
-
-  /@lit/reactive-element@1.6.2:
-    resolution: {integrity: sha512-rDfl+QnCYjuIGf5xI2sVJWdYIi56CTCwWa+nidKYX6oIuBYwUbT/vX4qbUDlHiZKJ/3FRNQ/tWJui44p6/stSA==}
+  /@lit/reactive-element@1.6.3:
+    resolution: {integrity: sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==}
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.1.1
 
   /@manypkg/find-root@1.1.0:
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
     dependencies:
-      '@babel/runtime': 7.22.3
+      '@babel/runtime': 7.22.11
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -765,7 +763,7 @@ packages:
   /@manypkg/get-packages@1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
     dependencies:
-      '@babel/runtime': 7.22.3
+      '@babel/runtime': 7.22.11
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -803,19 +801,19 @@ packages:
     resolution: {integrity: sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==}
     dev: false
 
-  /@types/emscripten@1.39.6:
-    resolution: {integrity: sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg==}
+  /@types/emscripten@1.39.7:
+    resolution: {integrity: sha512-tLqYV94vuqDrXh515F/FOGtBcRMTPGvVV1LzLbtYDcQmmhtpf/gLYf+hikBbQk8MzOHNz37wpFfJbYAuSn8HqA==}
     dev: false
 
   /@types/eslint-scope@3.7.4:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
     dependencies:
-      '@types/eslint': 8.40.0
+      '@types/eslint': 8.44.2
       '@types/estree': 1.0.1
     dev: false
 
-  /@types/eslint@8.40.0:
-    resolution: {integrity: sha512-nbq2mvc/tBrK9zQQuItvjJl++GTN5j06DaPtp3hZCpngmG6Q3xoyEmd0TwZI0gAy/G1X0zhGBbr2imsGFdFV0g==}
+  /@types/eslint@8.44.2:
+    resolution: {integrity: sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==}
     dependencies:
       '@types/estree': 1.0.1
       '@types/json-schema': 7.0.12
@@ -842,20 +840,20 @@ packages:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
     dev: true
 
-  /@types/node@14.18.48:
-    resolution: {integrity: sha512-iL0PIMwejpmuVHgfibHpfDwOdsbmB50wr21X71VnF5d7SsBF7WK+ZvP/SCcFm7Iwb9iiYSap9rlrdhToNAWdxg==}
+  /@types/node@16.18.46:
+    resolution: {integrity: sha512-Mnq3O9Xz52exs3mlxMcQuA7/9VFe/dXcrgAyfjLkABIqxXKOgBRjyazTxUbjsxDa4BP7hhPliyjVTP9RDP14xg==}
     dev: true
 
-  /@types/node@20.2.5:
-    resolution: {integrity: sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==}
+  /@types/node@20.5.7:
+    resolution: {integrity: sha512-dP7f3LdZIysZnmvP3ANJYTSwg+wLLl8p7RqniVlV7j+oXSXAbt9h0WIBFmJy5inWZoX9wZN6eXx+YXd9Rh3RBA==}
     dev: false
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
     dev: true
 
-  /@types/semver@7.5.0:
-    resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
+  /@types/semver@7.5.1:
+    resolution: {integrity: sha512-cJRQXpObxfNKkFAZbJl2yjWtJCqELQIdShsogr1d2MilP8dKD9TE/nEKHkJgUNHdGKCQaf9HbIynuV2csLGVLg==}
     dev: true
 
   /@types/sinonjs__fake-timers@8.1.1:
@@ -873,138 +871,139 @@ packages:
     resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==}
     requiresBuild: true
     dependencies:
-      '@types/node': 14.18.48
+      '@types/node': 16.18.46
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin@5.59.8(@typescript-eslint/parser@5.59.8)(eslint@8.41.0)(typescript@5.1.3):
-    resolution: {integrity: sha512-JDMOmhXteJ4WVKOiHXGCoB96ADWg9q7efPWHRViT/f09bA8XOMLAVHHju3l0MkZnG1izaWXYmgvQcUjTRcpShQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/eslint-plugin@6.5.0(@typescript-eslint/parser@6.5.0)(eslint@8.48.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-2pktILyjvMaScU6iK3925uvGU87E+N9rh372uGZgiMYwafaw9SXq86U04XPq3UH6tzRvNgBsub6x2DacHc33lw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
+      eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.59.8(eslint@8.41.0)(typescript@5.1.3)
-      '@typescript-eslint/scope-manager': 5.59.8
-      '@typescript-eslint/type-utils': 5.59.8(eslint@8.41.0)(typescript@5.1.3)
-      '@typescript-eslint/utils': 5.59.8(eslint@8.41.0)(typescript@5.1.3)
+      '@eslint-community/regexpp': 4.8.0
+      '@typescript-eslint/parser': 6.5.0(eslint@8.48.0)(typescript@5.2.2)
+      '@typescript-eslint/scope-manager': 6.5.0
+      '@typescript-eslint/type-utils': 6.5.0(eslint@8.48.0)(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.5.0(eslint@8.48.0)(typescript@5.2.2)
+      '@typescript-eslint/visitor-keys': 6.5.0
       debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.41.0
-      grapheme-splitter: 1.0.4
+      eslint: 8.48.0
+      graphemer: 1.4.0
       ignore: 5.2.4
-      natural-compare-lite: 1.4.0
-      semver: 7.5.1
-      tsutils: 3.21.0(typescript@5.1.3)
-      typescript: 5.1.3
+      natural-compare: 1.4.0
+      semver: 7.5.4
+      ts-api-utils: 1.0.2(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.59.8(eslint@8.41.0)(typescript@5.1.3):
-    resolution: {integrity: sha512-AnR19RjJcpjoeGojmwZtCwBX/RidqDZtzcbG3xHrmz0aHHoOcbWnpDllenRDmDvsV0RQ6+tbb09/kyc+UT9Orw==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/parser@6.5.0(eslint@8.48.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-LMAVtR5GN8nY0G0BadkG0XIe4AcNMeyEy3DyhKGAh9k4pLSMBO7rF29JvDBpZGCmp5Pgz5RLHP6eCpSYZJQDuQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/scope-manager': 5.59.8
-      '@typescript-eslint/types': 5.59.8
-      '@typescript-eslint/typescript-estree': 5.59.8(typescript@5.1.3)
+      '@typescript-eslint/scope-manager': 6.5.0
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.2.2)
+      '@typescript-eslint/visitor-keys': 6.5.0
       debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.41.0
-      typescript: 5.1.3
+      eslint: 8.48.0
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/scope-manager@5.59.8:
-    resolution: {integrity: sha512-/w08ndCYI8gxGf+9zKf1vtx/16y8MHrZs5/tnjHhMLNSixuNcJavSX4wAiPf4aS5x41Es9YPCn44MIe4cxIlig==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/scope-manager@6.5.0:
+    resolution: {integrity: sha512-A8hZ7OlxURricpycp5kdPTH3XnjG85UpJS6Fn4VzeoH4T388gQJ/PGP4ole5NfKt4WDVhmLaQ/dBLNDC4Xl/Kw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.59.8
-      '@typescript-eslint/visitor-keys': 5.59.8
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/visitor-keys': 6.5.0
     dev: true
 
-  /@typescript-eslint/type-utils@5.59.8(eslint@8.41.0)(typescript@5.1.3):
-    resolution: {integrity: sha512-+5M518uEIHFBy3FnyqZUF3BMP+AXnYn4oyH8RF012+e7/msMY98FhGL5SrN29NQ9xDgvqCgYnsOiKp1VjZ/fpA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/type-utils@6.5.0(eslint@8.48.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-f7OcZOkRivtujIBQ4yrJNIuwyCQO1OjocVqntl9dgSIZAdKqicj3xFDqDOzHDlGCZX990LqhLQXWRnQvsapq8A==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: '*'
+      eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.59.8(typescript@5.1.3)
-      '@typescript-eslint/utils': 5.59.8(eslint@8.41.0)(typescript@5.1.3)
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.2.2)
+      '@typescript-eslint/utils': 6.5.0(eslint@8.48.0)(typescript@5.2.2)
       debug: 4.3.4(supports-color@8.1.1)
-      eslint: 8.41.0
-      tsutils: 3.21.0(typescript@5.1.3)
-      typescript: 5.1.3
+      eslint: 8.48.0
+      ts-api-utils: 1.0.2(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/types@5.59.8:
-    resolution: {integrity: sha512-+uWuOhBTj/L6awoWIg0BlWy0u9TyFpCHrAuQ5bNfxDaZ1Ppb3mx6tUigc74LHcbHpOHuOTOJrBoAnhdHdaea1w==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/types@6.5.0:
+    resolution: {integrity: sha512-eqLLOEF5/lU8jW3Bw+8auf4lZSbbljHR2saKnYqON12G/WsJrGeeDHWuQePoEf9ro22+JkbPfWQwKEC5WwLQ3w==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.59.8(typescript@5.1.3):
-    resolution: {integrity: sha512-Jy/lPSDJGNow14vYu6IrW790p7HIf/SOV1Bb6lZ7NUkLc2iB2Z9elESmsaUtLw8kVqogSbtLH9tut5GCX1RLDg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/typescript-estree@6.5.0(typescript@5.2.2):
+    resolution: {integrity: sha512-q0rGwSe9e5Kk/XzliB9h2LBc9tmXX25G0833r7kffbl5437FPWb2tbpIV9wAATebC/018pGa9fwPDuvGN+LxWQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.59.8
-      '@typescript-eslint/visitor-keys': 5.59.8
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/visitor-keys': 6.5.0
       debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
-      semver: 7.5.1
-      tsutils: 3.21.0(typescript@5.1.3)
-      typescript: 5.1.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.2(typescript@5.2.2)
+      typescript: 5.2.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.59.8(eslint@8.41.0)(typescript@5.1.3):
-    resolution: {integrity: sha512-Tr65630KysnNn9f9G7ROF3w1b5/7f6QVCJ+WK9nhIocWmx9F+TmCAcglF26Vm7z8KCTwoKcNEBZrhlklla3CKg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/utils@6.5.0(eslint@8.48.0)(typescript@5.2.2):
+    resolution: {integrity: sha512-9nqtjkNykFzeVtt9Pj6lyR9WEdd8npPhhIPM992FWVkZuS6tmxHfGVnlUcjpUP2hv8r4w35nT33mlxd+Be1ACQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.41.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.48.0)
       '@types/json-schema': 7.0.12
-      '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 5.59.8
-      '@typescript-eslint/types': 5.59.8
-      '@typescript-eslint/typescript-estree': 5.59.8(typescript@5.1.3)
-      eslint: 8.41.0
-      eslint-scope: 5.1.1
-      semver: 7.5.1
+      '@types/semver': 7.5.1
+      '@typescript-eslint/scope-manager': 6.5.0
+      '@typescript-eslint/types': 6.5.0
+      '@typescript-eslint/typescript-estree': 6.5.0(typescript@5.2.2)
+      eslint: 8.48.0
+      semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: true
 
-  /@typescript-eslint/visitor-keys@5.59.8:
-    resolution: {integrity: sha512-pJhi2ms0x0xgloT7xYabil3SGGlojNNKjK/q6dB3Ey0uJLMjK2UDGJvHieiyJVW/7C3KI+Z4Q3pEHkm4ejA+xQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/visitor-keys@6.5.0:
+    resolution: {integrity: sha512-yCB/2wkbv3hPsh02ZS8dFQnij9VVQXJMN/gbQsaaY+zxALkZnxa/wagvLEFsAWMPv7d7lxQmNsIzGU1w/T/WyA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.59.8
-      eslint-visitor-keys: 3.4.1
+      '@typescript-eslint/types': 6.5.0
+      eslint-visitor-keys: 3.4.3
     dev: true
 
   /@webassemblyjs/ast@1.11.6:
@@ -1121,24 +1120,24 @@ packages:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
     dev: false
 
-  /acorn-import-assertions@1.9.0(acorn@8.8.2):
+  /acorn-import-assertions@1.9.0(acorn@8.10.0):
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
     peerDependencies:
       acorn: ^8
     dependencies:
-      acorn: 8.8.2
+      acorn: 8.10.0
     dev: false
 
-  /acorn-jsx@5.3.2(acorn@8.8.2):
+  /acorn-jsx@5.3.2(acorn@8.10.0):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      acorn: 8.8.2
+      acorn: 8.10.0
     dev: true
 
-  /acorn@8.8.2:
-    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
+  /acorn@8.10.0:
+    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -1299,8 +1298,8 @@ packages:
     resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
     dev: true
 
-  /axios@1.4.0:
-    resolution: {integrity: sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==}
+  /axios@1.5.0:
+    resolution: {integrity: sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==}
     dependencies:
       follow-redirects: 1.15.2
       form-data: 4.0.0
@@ -1368,15 +1367,15 @@ packages:
       wcwidth: 1.0.1
     dev: true
 
-  /browserslist@4.21.7:
-    resolution: {integrity: sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==}
+  /browserslist@4.21.10:
+    resolution: {integrity: sha512-bipEBdZfVH5/pwrvqc+Ub0kUPVfGUhlKxbvfD+z1BDnPEO/X98ruXGA1WP5ASpAFKan7Qr6j736IacbZQuAlKQ==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001492
-      electron-to-chromium: 1.4.419
-      node-releases: 2.0.12
-      update-browserslist-db: 1.0.11(browserslist@4.21.7)
+      caniuse-lite: 1.0.30001524
+      electron-to-chromium: 1.4.505
+      node-releases: 2.0.13
+      update-browserslist-db: 1.0.11(browserslist@4.21.10)
     dev: false
 
   /buffer-crc32@0.2.13:
@@ -1394,8 +1393,8 @@ packages:
       ieee754: 1.2.1
     dev: true
 
-  /cachedir@2.3.0:
-    resolution: {integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==}
+  /cachedir@2.4.0:
+    resolution: {integrity: sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==}
     engines: {node: '>=6'}
     dev: true
 
@@ -1425,8 +1424,8 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /caniuse-lite@1.0.30001492:
-    resolution: {integrity: sha512-2efF8SAZwgAX1FJr87KWhvuJxnGJKOnctQa8xLOskAXNXq8oiuqgl6u1kk3fFpsp3GgvzlRjiK1sl63hNtFADw==}
+  /caniuse-lite@1.0.30001524:
+    resolution: {integrity: sha512-Jj917pJtYg9HSJBF95HVX3Cdr89JUyLT4IZ8SvM5aDRni95swKgYi3TgYLH5hnGfPE/U1dg6IfZ50UsIlLkwSA==}
     dev: false
 
   /caseless@0.12.0:
@@ -1471,7 +1470,7 @@ packages:
       normalize-path: 3.0.0
       readdirp: 3.6.0
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /chownr@2.0.0:
@@ -1637,39 +1636,39 @@ packages:
       stream-transform: 2.1.3
     dev: true
 
-  /cypress-lit@0.0.7(cypress@12.13.0):
-    resolution: {integrity: sha512-1w0zXeO/1/XiePk/L7NIgc35mVxAq1qK36Ay7WVG+62z0LIS57ELHcdhZdclLc4fHa0V9I9Fvb4UZg3qdMpHCw==}
+  /cypress-lit@0.0.8(cypress@13.0.0):
+    resolution: {integrity: sha512-HOVhMYbgvN9mhlV1OH6XTwYGGN4hMeaIamkztRUtK7KvBItlnZBrjj6il7JToQ/CFcL4NoVr/d5B9rFS3V5jKA==}
     peerDependencies:
       cypress: '>=10.6.0'
     dependencies:
-      cypress: 12.13.0
+      cypress: 13.0.0
     dev: true
 
-  /cypress@12.13.0:
-    resolution: {integrity: sha512-QJlSmdPk+53Zhy69woJMySZQJoWfEWun3X5OOenGsXjRPVfByVTHorxNehbzhZrEzH9RDUDqVcck0ahtlS+N/Q==}
-    engines: {node: ^14.0.0 || ^16.0.0 || >=18.0.0}
+  /cypress@13.0.0:
+    resolution: {integrity: sha512-nWHU5dUxP2Wm/zrMd8SWTTl706aJex/l+H4vi/tbu2SWUr17BUcd/sIYeqyxeoSPW1JFV2pT1pf4JEImH/POMg==}
+    engines: {node: ^16.0.0 || ^18.0.0 || >=20.0.0}
     hasBin: true
     requiresBuild: true
     dependencies:
-      '@cypress/request': 2.88.11
+      '@cypress/request': 3.0.0
       '@cypress/xvfb': 1.2.4(supports-color@8.1.1)
-      '@types/node': 14.18.48
+      '@types/node': 16.18.46
       '@types/sinonjs__fake-timers': 8.1.1
       '@types/sizzle': 2.3.3
       arch: 2.2.0
       blob-util: 2.0.2
       bluebird: 3.7.2
       buffer: 5.7.1
-      cachedir: 2.3.0
+      cachedir: 2.4.0
       chalk: 4.1.2
       check-more-types: 2.24.0
       cli-cursor: 3.1.0
       cli-table3: 0.6.3
       commander: 6.2.1
       common-tags: 1.8.2
-      dayjs: 1.11.8
+      dayjs: 1.11.9
       debug: 4.3.4(supports-color@8.1.1)
-      enquirer: 2.3.6
+      enquirer: 2.4.1
       eventemitter2: 6.4.7
       execa: 4.1.0
       executable: 4.1.1
@@ -1680,15 +1679,16 @@ packages:
       is-ci: 3.0.1
       is-installed-globally: 0.4.0
       lazy-ass: 1.6.0
-      listr2: 3.14.0(enquirer@2.3.6)
+      listr2: 3.14.0(enquirer@2.4.1)
       lodash: 4.17.21
       log-symbols: 4.1.0
       minimist: 1.2.8
       ospath: 1.2.2
       pretty-bytes: 5.6.0
+      process: 0.11.10
       proxy-from-env: 1.0.0
       request-progress: 3.0.0
-      semver: 7.5.1
+      semver: 7.5.4
       supports-color: 8.1.1
       tmp: 0.2.1
       untildify: 4.0.0
@@ -1702,8 +1702,8 @@ packages:
       assert-plus: 1.0.0
     dev: true
 
-  /dayjs@1.11.8:
-    resolution: {integrity: sha512-LcgxzFoWMEPO7ggRv1Y2N31hUf2R0Vj7fuy/m+Bg1K8rr+KAs1AEy4y9jd5DXe8pbHgX+srkHNS7TH6Q6ZhYeQ==}
+  /dayjs@1.11.9:
+    resolution: {integrity: sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA==}
     dev: true
 
   /debug@3.2.7(supports-color@8.1.1):
@@ -1791,8 +1791,8 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
-  /electron-to-chromium@1.4.419:
-    resolution: {integrity: sha512-jdie3RiEgygvDTyS2sgjq71B36q2cDSBfPlwzUyuOrfYTNoYWyBxxjGJV/HAu3A2hB0Y+HesvCVkVAFoCKwCSw==}
+  /electron-to-chromium@1.4.505:
+    resolution: {integrity: sha512-0A50eL5BCCKdxig2SsCXhpuztnB9PfUgRMojj5tMvt8O54lbwz3t6wNgnpiTRosw5QjlJB7ixhVyeg8daLQwSQ==}
     dev: false
 
   /emoji-regex@8.0.0:
@@ -1805,12 +1805,12 @@ packages:
       once: 1.4.0
     dev: true
 
-  /engine.io-client@6.5.1:
-    resolution: {integrity: sha512-hE5wKXH8Ru4L19MbM1GgYV/2Qo54JSMh1rlJbfpa40bEWkCKNo3ol2eOtGmowcr+ysgbI7+SGL+by42Q3pt/Ng==}
+  /engine.io-client@6.5.2:
+    resolution: {integrity: sha512-CQZqbrpEYnrpGqC07a9dJDz4gePZUgTPMU3NKJPSeQOyw27Tst4Pl3FemKoFGAlHzgZmKjoRmiJvbWfhCXUlIg==}
     dependencies:
       '@socket.io/component-emitter': 3.1.0
       debug: 4.3.4(supports-color@8.1.1)
-      engine.io-parser: 5.1.0
+      engine.io-parser: 5.2.1
       ws: 8.11.0
       xmlhttprequest-ssl: 2.0.0
     transitivePeerDependencies:
@@ -1819,24 +1819,25 @@ packages:
       - utf-8-validate
     dev: false
 
-  /engine.io-parser@5.1.0:
-    resolution: {integrity: sha512-enySgNiK5tyZFynt3z7iqBR+Bto9EVVVvDFuTT0ioHCGbzirZVGDGiQjZzEp8hWl6hd5FSVytJGuScX1C1C35w==}
+  /engine.io-parser@5.2.1:
+    resolution: {integrity: sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==}
     engines: {node: '>=10.0.0'}
     dev: false
 
-  /enhanced-resolve@5.14.1:
-    resolution: {integrity: sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==}
+  /enhanced-resolve@5.15.0:
+    resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.1
     dev: false
 
-  /enquirer@2.3.6:
-    resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
+  /enquirer@2.4.1:
+    resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
     dependencies:
       ansi-colors: 4.1.3
+      strip-ansi: 6.0.1
     dev: true
 
   /error-ex@1.3.2:
@@ -1855,7 +1856,7 @@ packages:
       call-bind: 1.0.2
       es-set-tostringtag: 2.0.1
       es-to-primitive: 1.2.1
-      function.prototype.name: 1.1.5
+      function.prototype.name: 1.1.6
       get-intrinsic: 1.2.1
       get-symbol-description: 1.0.0
       globalthis: 1.0.3
@@ -1890,8 +1891,8 @@ packages:
       which-typed-array: 1.1.11
     dev: true
 
-  /es-module-lexer@1.2.1:
-    resolution: {integrity: sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==}
+  /es-module-lexer@1.3.0:
+    resolution: {integrity: sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==}
     dev: false
 
   /es-set-tostringtag@2.0.1:
@@ -1918,34 +1919,34 @@ packages:
       is-symbol: 1.0.4
     dev: true
 
-  /esbuild@0.17.19:
-    resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
+  /esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
     engines: {node: '>=12'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      '@esbuild/android-arm': 0.17.19
-      '@esbuild/android-arm64': 0.17.19
-      '@esbuild/android-x64': 0.17.19
-      '@esbuild/darwin-arm64': 0.17.19
-      '@esbuild/darwin-x64': 0.17.19
-      '@esbuild/freebsd-arm64': 0.17.19
-      '@esbuild/freebsd-x64': 0.17.19
-      '@esbuild/linux-arm': 0.17.19
-      '@esbuild/linux-arm64': 0.17.19
-      '@esbuild/linux-ia32': 0.17.19
-      '@esbuild/linux-loong64': 0.17.19
-      '@esbuild/linux-mips64el': 0.17.19
-      '@esbuild/linux-ppc64': 0.17.19
-      '@esbuild/linux-riscv64': 0.17.19
-      '@esbuild/linux-s390x': 0.17.19
-      '@esbuild/linux-x64': 0.17.19
-      '@esbuild/netbsd-x64': 0.17.19
-      '@esbuild/openbsd-x64': 0.17.19
-      '@esbuild/sunos-x64': 0.17.19
-      '@esbuild/win32-arm64': 0.17.19
-      '@esbuild/win32-ia32': 0.17.19
-      '@esbuild/win32-x64': 0.17.19
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
     dev: true
 
   /escalade@3.1.1:
@@ -1968,30 +1969,31 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 4.3.0
+    dev: false
 
-  /eslint-scope@7.2.0:
-    resolution: {integrity: sha512-DYj5deGlHBfMt15J7rdtyKNq/Nqlv5KfU4iodrQ019XESsRnwXH9KAE0y3cwtUHDo2ob7CypAnCqefh6vioWRw==}
+  /eslint-scope@7.2.2:
+    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
     dev: true
 
-  /eslint-visitor-keys@3.4.1:
-    resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
+  /eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /eslint@8.41.0:
-    resolution: {integrity: sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==}
+  /eslint@8.48.0:
+    resolution: {integrity: sha512-sb6DLeIuRXxeM1YljSe1KEx9/YYeZFQWcV8Rq9HfigmdDEugjLEVEa1ozDjL6YDjBpQHPJxJzze+alxi4T3OLg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.41.0)
-      '@eslint-community/regexpp': 4.5.1
-      '@eslint/eslintrc': 2.0.3
-      '@eslint/js': 8.41.0
-      '@humanwhocodes/config-array': 0.11.10
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.48.0)
+      '@eslint-community/regexpp': 4.8.0
+      '@eslint/eslintrc': 2.1.2
+      '@eslint/js': 8.48.0
+      '@humanwhocodes/config-array': 0.11.11
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       ajv: 6.12.6
@@ -2000,19 +2002,18 @@ packages:
       debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
-      eslint-scope: 7.2.0
-      eslint-visitor-keys: 3.4.1
-      espree: 9.5.2
+      eslint-scope: 7.2.2
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
       esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
       find-up: 5.0.0
       glob-parent: 6.0.2
-      globals: 13.20.0
+      globals: 13.21.0
       graphemer: 1.4.0
       ignore: 5.2.4
-      import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
@@ -2022,21 +2023,20 @@ packages:
       lodash.merge: 4.6.2
       minimatch: 3.1.2
       natural-compare: 1.4.0
-      optionator: 0.9.1
+      optionator: 0.9.3
       strip-ansi: 6.0.1
-      strip-json-comments: 3.1.1
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /espree@9.5.2:
-    resolution: {integrity: sha512-7OASN1Wma5fum5SrNhFMAMJxOUAbhyfQ8dQ//PJaJbNw0URTPWqIghHWt1MmAANKhHZIYOHruW4Kw4ruUWOdGw==}
+  /espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      acorn: 8.8.2
-      acorn-jsx: 5.3.2(acorn@8.8.2)
-      eslint-visitor-keys: 3.4.1
+      acorn: 8.10.0
+      acorn-jsx: 5.3.2(acorn@8.10.0)
+      eslint-visitor-keys: 3.4.3
     dev: true
 
   /esprima@4.0.1:
@@ -2061,6 +2061,7 @@ packages:
   /estraverse@4.3.0:
     resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
+    dev: false
 
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
@@ -2145,8 +2146,8 @@ packages:
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  /fast-glob@3.2.12:
-    resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
+  /fast-glob@3.3.1:
+    resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
     engines: {node: '>=8.6.0'}
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2186,7 +2187,7 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     dependencies:
-      flat-cache: 3.0.4
+      flat-cache: 3.1.0
     dev: true
 
   /fill-range@7.0.1:
@@ -2219,11 +2220,12 @@ packages:
       pkg-dir: 4.2.0
     dev: true
 
-  /flat-cache@3.0.4:
-    resolution: {integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==}
-    engines: {node: ^10.12.0 || >=12.0.0}
+  /flat-cache@3.1.0:
+    resolution: {integrity: sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==}
+    engines: {node: '>=12.0.0'}
     dependencies:
       flatted: 3.2.7
+      keyv: 4.5.3
       rimraf: 3.0.2
     dev: true
 
@@ -2324,8 +2326,8 @@ packages:
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
-  /fsevents@2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+  /fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
@@ -2336,8 +2338,8 @@ packages:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
     dev: true
 
-  /function.prototype.name@1.1.5:
-    resolution: {integrity: sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==}
+  /function.prototype.name@1.1.6:
+    resolution: {integrity: sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -2446,8 +2448,8 @@ packages:
       ini: 2.0.0
     dev: true
 
-  /globals@13.20.0:
-    resolution: {integrity: sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==}
+  /globals@13.21.0:
+    resolution: {integrity: sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==}
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.20.2
@@ -2466,7 +2468,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.12
+      fast-glob: 3.3.1
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
@@ -2575,11 +2577,11 @@ packages:
     engines: {node: '>= 4'}
     dev: true
 
-  /imjoy-rpc@0.5.42:
-    resolution: {integrity: sha512-X7u2UsF5w0XkOtQf9dZIMnDUutiQ52YEYKbj1rIQmSpC2yWOgC67AkVvCHBz0mH7iGILQoQKtaOuEAbu4o1OQQ==}
+  /imjoy-rpc@0.5.44:
+    resolution: {integrity: sha512-H0MaStrtRtz1pdG8moynG9Zd0jfvgWRur1DHP7duYNFitFOaDh20q8J+ehEOusByZcVFtPDtDeYNbA8gy751YA==}
     dependencies:
       '@msgpack/msgpack': 2.8.0
-      socket.io-client: 4.7.1
+      socket.io-client: 4.7.2
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -2816,30 +2818,13 @@ packages:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
     dev: true
 
-  /itk-wasm@1.0.0-b.112:
-    resolution: {integrity: sha512-bAo0RuUpBE6Rmj3c2rjt3dBzHr2+wDxT/pL9nHwQevyk14DaJZSHWELRwCOJgJ8kGRAeVo+EB1wDB2H+HKr6ug==}
+  /itk-wasm@1.0.0-b.133:
+    resolution: {integrity: sha512-8buMFL1AkXq/nucUrxL5X0/w2nSivxNEbatoFMgU54d7dGAjIod2O/epHTT8p+wWXJ/pTMVmRoSzBFG9pxRiUA==}
     hasBin: true
     dependencies:
-      '@babel/runtime': 7.22.3
-      '@types/emscripten': 1.39.6
-      axios: 1.4.0
-      commander: 9.5.0
-      fs-extra: 10.1.0
-      glob: 8.1.0
-      markdown-table: 3.0.3
-      mime-types: 2.1.35
-      webworker-promise: 0.4.4
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
-  /itk-wasm@1.0.0-b.129:
-    resolution: {integrity: sha512-M9Qsux/q3739CtvHoDdWI8qVILk5tg1SASnWuwIuLemDQonvM0kq0aUw1b8VGF/2rcdYVec3fqPnC5ng9woOAw==}
-    hasBin: true
-    dependencies:
-      '@babel/runtime': 7.22.3
-      '@types/emscripten': 1.39.6
-      axios: 1.4.0
+      '@babel/runtime': 7.22.11
+      '@types/emscripten': 1.39.7
+      axios: 1.5.0
       commander: 9.5.0
       fs-extra: 10.1.0
       glob: 8.1.0
@@ -2855,7 +2840,7 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/node': 20.2.5
+      '@types/node': 20.5.7
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: false
@@ -2881,6 +2866,10 @@ packages:
 
   /jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
+    dev: true
+
+  /json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
     dev: true
 
   /json-parse-even-better-errors@2.3.1:
@@ -2924,6 +2913,12 @@ packages:
       verror: 1.10.0
     dev: true
 
+  /keyv@4.5.3:
+    resolution: {integrity: sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==}
+    dependencies:
+      json-buffer: 3.0.1
+    dev: true
+
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
@@ -2951,7 +2946,7 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
-  /listr2@3.14.0(enquirer@2.3.6):
+  /listr2@3.14.0(enquirer@2.4.1):
     resolution: {integrity: sha512-TyWI8G99GX9GjE54cJ+RrNMcIFBfwMPxc3XTFiAYGN4s10hWROGtOg7+O6u6LE3mNkyld7RSLE6nrKBvTfcs3g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -2962,7 +2957,7 @@ packages:
     dependencies:
       cli-truncate: 2.1.0
       colorette: 2.0.20
-      enquirer: 2.3.6
+      enquirer: 2.4.1
       log-update: 4.0.0
       p-map: 4.0.0
       rfdc: 1.3.0
@@ -2971,33 +2966,24 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
-  /lit-element@3.3.2:
-    resolution: {integrity: sha512-xXAeVWKGr4/njq0rGC9dethMnYCq5hpKYrgQZYTzawt9YQhMiXfD+T1RgrdY3NamOxwq2aXlb0vOI6e29CKgVQ==}
+  /lit-element@3.3.3:
+    resolution: {integrity: sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==}
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.1.1
-      '@lit/reactive-element': 1.6.2
-      lit-html: 2.7.4
+      '@lit/reactive-element': 1.6.3
+      lit-html: 2.8.0
 
-  /lit-html@2.7.4:
-    resolution: {integrity: sha512-/Jw+FBpeEN+z8X6PJva5n7+0MzCVAH2yypN99qHYYkq8bI+j7I39GH+68Z/MZD6rGKDK9RpzBw7CocfmHfq6+g==}
+  /lit-html@2.8.0:
+    resolution: {integrity: sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==}
     dependencies:
       '@types/trusted-types': 2.0.3
 
-  /lit@2.7.4:
-    resolution: {integrity: sha512-cgD7xrZoYr21mbrkZIuIrj98YTMw/snJPg52deWVV4A8icLyNHI3bF70xsJeAgwTuiq5Kkd+ZR8gybSJDCPB7g==}
+  /lit@2.8.0:
+    resolution: {integrity: sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==}
     dependencies:
-      '@lit/reactive-element': 1.6.1
-      lit-element: 3.3.2
-      lit-html: 2.7.4
-    dev: false
-
-  /lit@2.7.5:
-    resolution: {integrity: sha512-i/cH7Ye6nBDUASMnfwcictBnsTN91+aBjXoTHF2xARghXScKxpD4F4WYI+VLXg9lqbMinDfvoI7VnZXjyHgdfQ==}
-    dependencies:
-      '@lit/reactive-element': 1.6.2
-      lit-element: 3.3.2
-      lit-html: 2.7.4
-    dev: true
+      '@lit/reactive-element': 1.6.3
+      lit-element: 3.3.3
+      lit-html: 2.8.0
 
   /load-yaml-file@0.2.0:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
@@ -3213,10 +3199,6 @@ packages:
     hasBin: true
     dev: true
 
-  /natural-compare-lite@1.4.0:
-    resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
-    dev: true
-
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
@@ -3225,8 +3207,8 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: false
 
-  /node-releases@2.0.12:
-    resolution: {integrity: sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==}
+  /node-releases@2.0.13:
+    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
     dev: false
 
   /normalize-package-data@2.5.0:
@@ -3281,16 +3263,16 @@ packages:
       mimic-fn: 2.1.0
     dev: true
 
-  /optionator@0.9.1:
-    resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
+  /optionator@0.9.3:
+    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
     dependencies:
+      '@aashutoshrathi/word-wrap': 1.2.6
       deep-is: 0.1.4
       fast-levenshtein: 2.0.6
       levn: 0.4.1
       prelude-ls: 1.2.1
       type-check: 0.4.0
-      word-wrap: 1.2.3
     dev: true
 
   /orbit-camera@1.0.0:
@@ -3388,7 +3370,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.22.10
+      '@babel/code-frame': 7.22.13
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -3451,8 +3433,8 @@ packages:
       find-up: 4.1.0
     dev: true
 
-  /postcss@8.4.24:
-    resolution: {integrity: sha512-M0RzbcI0sO/XJNucsGjvWU9ERWxb/ytp1w6dKtxTKgixdtQDq4rmx/g8W1hnaheq9jgwL/oyEdH5Bc4WwJKMqg==}
+  /postcss@8.4.29:
+    resolution: {integrity: sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.6
@@ -3481,9 +3463,20 @@ packages:
     hasBin: true
     dev: true
 
+  /prettier@3.0.3:
+    resolution: {integrity: sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: true
+
   /pretty-bytes@5.6.0:
     resolution: {integrity: sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==}
     engines: {node: '>=6'}
+    dev: true
+
+  /process@0.11.10:
+    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
+    engines: {node: '>= 0.6.0'}
     dev: true
 
   /proxy-from-env@1.0.0:
@@ -3518,6 +3511,10 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
+    dev: true
+
+  /querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
     dev: true
 
   /queue-microtask@1.2.3:
@@ -3579,8 +3576,8 @@ packages:
       strip-indent: 3.0.0
     dev: true
 
-  /regenerator-runtime@0.13.11:
-    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+  /regenerator-runtime@0.14.0:
+    resolution: {integrity: sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA==}
 
   /regexp.prototype.flags@1.5.0:
     resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
@@ -3604,6 +3601,10 @@ packages:
 
   /require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+    dev: true
+
+  /requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
     dev: true
 
   /resolve-from@4.0.0:
@@ -3649,12 +3650,12 @@ packages:
       glob: 7.2.3
     dev: true
 
-  /rollup@3.23.0:
-    resolution: {integrity: sha512-h31UlwEi7FHihLe1zbk+3Q7z1k/84rb9BSwmBSr/XjOCEaBJ2YyedQDuM0t/kfOS0IxM+vk1/zI9XxYj9V+NJQ==}
+  /rollup@3.28.1:
+    resolution: {integrity: sha512-R9OMQmIHJm9znrU3m3cpE8uhN0fGdXiawME7aZIpQqvpS/85+Vt1Hq1/yVIcYfOmaQiHjvXkQAoJukvLpau6Yw==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /run-parallel@1.2.0:
@@ -3666,7 +3667,7 @@ packages:
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.5.3
+      tslib: 2.6.2
     dev: true
 
   /safe-array-concat@1.0.0:
@@ -3694,8 +3695,8 @@ packages:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
     dev: true
 
-  /schema-utils@3.1.2:
-    resolution: {integrity: sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==}
+  /schema-utils@3.3.0:
+    resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
       '@types/json-schema': 7.0.12
@@ -3706,14 +3707,6 @@ packages:
   /semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
-    dev: true
-
-  /semver@7.5.1:
-    resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
     dev: true
 
   /semver@7.5.4:
@@ -3806,13 +3799,13 @@ packages:
       yargs: 15.4.1
     dev: true
 
-  /socket.io-client@4.7.1:
-    resolution: {integrity: sha512-Qk3Xj8ekbnzKu3faejo4wk2MzXA029XppiXtTF/PkbTg+fcwaTw1PlDrTrrrU4mKoYC4dvlApOnSeyLCKwek2w==}
+  /socket.io-client@4.7.2:
+    resolution: {integrity: sha512-vtA0uD4ibrYD793SOIAwlo8cj6haOeMHrGvwPxJsxH7CeIksqJ+3Zc06RvWTIFgiSqx4A3sOnTXpfAEE2Zyz6w==}
     engines: {node: '>=10.0.0'}
     dependencies:
       '@socket.io/component-emitter': 3.1.0
       debug: 4.3.4(supports-color@8.1.1)
-      engine.io-client: 6.5.1
+      engine.io-client: 6.5.2
       socket.io-parser: 4.2.4
     transitivePeerDependencies:
       - bufferutil
@@ -4012,7 +4005,7 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /terser-webpack-plugin@5.3.9(webpack@5.85.0):
+  /terser-webpack-plugin@5.3.9(webpack@5.88.2):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -4028,21 +4021,21 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.19
       jest-worker: 27.5.1
-      schema-utils: 3.1.2
+      schema-utils: 3.3.0
       serialize-javascript: 6.0.1
-      terser: 5.17.7
-      webpack: 5.85.0
+      terser: 5.19.3
+      webpack: 5.88.2
     dev: false
 
-  /terser@5.17.7:
-    resolution: {integrity: sha512-/bi0Zm2C6VAexlGgLlVxA0P2lru/sdLyfCVaRMfKVo9nWxbmz7f/sD8VPybPeSUJaJcwmCJis9pBIhcVcG1QcQ==}
+  /terser@5.19.3:
+    resolution: {integrity: sha512-pQzJ9UJzM0IgmT4FAtYI6+VqFf0lj/to58AV0Xfgg0Up37RyPG7Al+1cepC6/BVuAxR9oNb41/DL4DEoHJvTdg==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      '@jridgewell/source-map': 0.3.3
-      acorn: 8.8.2
+      '@jridgewell/source-map': 0.3.5
+      acorn: 8.10.0
       commander: 2.20.3
       source-map-support: 0.5.21
     dev: false
@@ -4080,12 +4073,14 @@ packages:
       is-number: 7.0.0
     dev: true
 
-  /tough-cookie@2.5.0:
-    resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
-    engines: {node: '>=0.8'}
+  /tough-cookie@4.1.3:
+    resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
+    engines: {node: '>=6'}
     dependencies:
       psl: 1.9.0
       punycode: 2.3.0
+      universalify: 0.2.0
+      url-parse: 1.5.10
     dev: true
 
   /trim-newlines@3.0.1:
@@ -4093,22 +4088,17 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
-    dev: true
-
-  /tslib@2.5.3:
-    resolution: {integrity: sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==}
-    dev: true
-
-  /tsutils@3.21.0(typescript@5.1.3):
-    resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
-    engines: {node: '>= 6'}
+  /ts-api-utils@1.0.2(typescript@5.2.2):
+    resolution: {integrity: sha512-Cbu4nIqnEdd+THNEsBdkolnOXhg0I8XteoHaEKgvsxpsbWda4IsUut2c187HxywQCvveojow0Dgw/amxtSKVkQ==}
+    engines: {node: '>=16.13.0'}
     peerDependencies:
-      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+      typescript: '>=4.2.0'
     dependencies:
-      tslib: 1.14.1
-      typescript: 5.1.3
+      typescript: 5.2.2
+    dev: true
+
+  /tslib@2.6.2:
+    resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
 
   /tty-table@4.2.1:
@@ -4205,20 +4195,8 @@ packages:
       is-typed-array: 1.1.12
     dev: true
 
-  /typescript@4.8.4:
-    resolution: {integrity: sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==}
-    engines: {node: '>=4.2.0'}
-    hasBin: true
-    dev: true
-
-  /typescript@5.0.4:
-    resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
-    engines: {node: '>=12.20'}
-    hasBin: true
-    dev: true
-
-  /typescript@5.1.3:
-    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
+  /typescript@5.2.2:
+    resolution: {integrity: sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -4237,6 +4215,11 @@ packages:
     engines: {node: '>= 4.0.0'}
     dev: true
 
+  /universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+    dev: true
+
   /universalify@2.0.0:
     resolution: {integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==}
     engines: {node: '>= 10.0.0'}
@@ -4246,13 +4229,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /update-browserslist-db@1.0.11(browserslist@4.21.7):
+  /update-browserslist-db@1.0.11(browserslist@4.21.10):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.21.7
+      browserslist: 4.21.10
       escalade: 3.1.1
       picocolors: 1.0.0
     dev: false
@@ -4261,6 +4244,13 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.0
+
+  /url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
+    dev: true
 
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -4283,26 +4273,27 @@ packages:
       extsprintf: 1.3.0
     dev: true
 
-  /vite-plugin-static-copy@0.15.0(vite@4.3.9):
-    resolution: {integrity: sha512-Ww+/Ug9guV45oIfIi/lA2z8v3K+lLHV9zCJqTVO4FTdqrJoZBj68VgGBSH1fi0N4q/EHW32RsL3ympi4Wlsq5w==}
+  /vite-plugin-static-copy@0.17.0(vite@4.4.9):
+    resolution: {integrity: sha512-2HpNbHfDt8SDy393AGXh9llHkc8FJMQkI8s3T5WsH3SWLMO+f5cFIyPErl4yGKU9Uh3Vaqsd4lHZYTf042fQ2A==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
       vite: ^3.0.0 || ^4.0.0
     dependencies:
       chokidar: 3.5.3
-      fast-glob: 3.2.12
+      fast-glob: 3.3.1
       fs-extra: 11.1.1
       picocolors: 1.0.0
-      vite: 4.3.9
+      vite: 4.4.9
     dev: true
 
-  /vite@4.3.9:
-    resolution: {integrity: sha512-qsTNZjO9NoJNW7KnOrgYwczm0WctJ8m/yqYAMAK9Lxt4SoySUfS5S8ia9K7JHpa3KEeMfyF8LoJ3c5NeBJy6pg==}
+  /vite@4.4.9:
+    resolution: {integrity: sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
       '@types/node': '>= 14'
       less: '*'
+      lightningcss: ^1.21.0
       sass: '*'
       stylus: '*'
       sugarss: '*'
@@ -4311,6 +4302,8 @@ packages:
       '@types/node':
         optional: true
       less:
+        optional: true
+      lightningcss:
         optional: true
       sass:
         optional: true
@@ -4321,11 +4314,11 @@ packages:
       terser:
         optional: true
     dependencies:
-      esbuild: 0.17.19
-      postcss: 8.4.24
-      rollup: 3.23.0
+      esbuild: 0.18.20
+      postcss: 8.4.29
+      rollup: 3.28.1
     optionalDependencies:
-      fsevents: 2.3.2
+      fsevents: 2.3.3
     dev: true
 
   /wasm-feature-detect@1.5.1:
@@ -4351,8 +4344,8 @@ packages:
     engines: {node: '>=10.13.0'}
     dev: false
 
-  /webpack@5.85.0:
-    resolution: {integrity: sha512-7gazTiYqwo5OSqwH1tigLDL2r3qDeP2dOKYgd+LlXpsUMqDTklg6tOghexqky0/+6QY38kb/R/uRPUleuL43zg==}
+  /webpack@5.88.2:
+    resolution: {integrity: sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -4366,12 +4359,12 @@ packages:
       '@webassemblyjs/ast': 1.11.6
       '@webassemblyjs/wasm-edit': 1.11.6
       '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.8.2
-      acorn-import-assertions: 1.9.0(acorn@8.8.2)
-      browserslist: 4.21.7
+      acorn: 8.10.0
+      acorn-import-assertions: 1.9.0(acorn@8.10.0)
+      browserslist: 4.21.10
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.14.1
-      es-module-lexer: 1.2.1
+      enhanced-resolve: 5.15.0
+      es-module-lexer: 1.3.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -4380,9 +4373,9 @@ packages:
       loader-runner: 4.3.0
       mime-types: 2.1.35
       neo-async: 2.6.2
-      schema-utils: 3.1.2
+      schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(webpack@5.85.0)
+      terser-webpack-plugin: 5.3.9(webpack@5.88.2)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -4398,7 +4391,7 @@ packages:
   /webworker-promise@0.5.1:
     resolution: {integrity: sha512-KiHNwAWKVM5fyqssxD9TZb977qE9xsXYxYKxDogRefYdwDuDlGIJCGMd8nA1/bXoqa66E8JOIwgl8YEHOV0pIw==}
     dependencies:
-      webpack: 5.85.0
+      webpack: 5.88.2
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -4454,11 +4447,6 @@ packages:
       isexe: 2.0.0
     dev: true
 
-  /word-wrap@1.2.3:
-    resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
-    engines: {node: '>=0.10.0'}
-    dev: true
-
   /wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -4498,7 +4486,7 @@ packages:
     engines: {node: '>=0.4.0'}
     dev: false
 
-  /xstate-lit@1.3.1(lit@2.7.4)(xstate@4.38.2):
+  /xstate-lit@1.3.1(lit@2.8.0)(xstate@4.38.2):
     resolution: {integrity: sha512-p/HiJLTSVtPYV81MzeEe8WDe4cP/Rqc4b9KgeRIN5CTyf/76TspzWYAYCjUJiEHojJGGO8lo0d8IqjO+iIrr/g==}
     peerDependencies:
       '@lit-labs/context': ^0.2.0
@@ -4508,7 +4496,7 @@ packages:
       '@lit-labs/context':
         optional: true
     dependencies:
-      lit: 2.7.4
+      lit: 2.8.0
       xstate: 4.38.2
     dev: false
 
@@ -4516,8 +4504,8 @@ packages:
     resolution: {integrity: sha512-Fba/DwEPDLneHT3tbJ9F3zafbQXszOlyCJyQqqdzmtlY/cwE2th462KK48yaANf98jHlP6lJvxfNtN0LFKXPQg==}
     dev: false
 
-  /xstate@5.0.0-beta.18:
-    resolution: {integrity: sha512-sRRb/8SM6UxeaP1dTdIKZ2Ktk4v9xLbZZ2+xRVCBEWSIfWngpZjGuYq5pIkkXWf1uO/7Fb2eBovM9V+IkEqPXg==}
+  /xstate@5.0.0-beta.24:
+    resolution: {integrity: sha512-Ti43pA1RYptHiRlaIrUmVE9CJQe+FFBsQZP7w+n0a4R4ywFtuLcec7qUSHxRplsCAhlJNkEWMBeiW4yc1RrNRg==}
     dev: false
 
   /y18n@4.0.3:
@@ -4592,6 +4580,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /zod@3.21.4:
-    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
+  /zod@3.22.2:
+    resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
     dev: false

--- a/tsconfig.root.json
+++ b/tsconfig.root.json
@@ -16,6 +16,7 @@
     "forceConsistentCasingInFileNames": true,
     "useDefineForClassFields": false,
     "skipLibCheck": true,
+    "sourceMap": true,
     "allowJs": true
   }
 }

--- a/tsconfig.root.json
+++ b/tsconfig.root.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "NodeNext",
     "lib": ["ES2019", "DOM", "DOM.Iterable"],
     "target": "ES2019",
     "declaration": true,
@@ -9,7 +9,7 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "moduleResolution": "nodenext",
+    "moduleResolution": "NodeNext",
     "isolatedModules": true,
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,


### PR DESCRIPTION
1. To represet images for RemoteViewport client side, app layer code creates a MutliscaleSpatialImage stub with `makePlaceholderMultiscaleImage()`.  This image instance has the number of scales.
2. App calls `viewer.send({ type: 'addImage', image, name: image.name });` and viewer forwards image to viewports.
3. RemoteViewport observes Viewport. Sees number of image scales.
4. RemoteViewport sends change imageScale messages to remote server.