### PR TITLE
fix(remote-machine): do async change image scale

### DIFF
--- a/.changeset/spotty-moose-prove.md
+++ b/.changeset/spotty-moose-prove.md
@@ -1,0 +1,8 @@
+---
+'@itk-viewer/remote-viewport': patch
+'@itk-viewer/element': patch
+'@itk-viewer/viewer': patch
+'@itk-viewer/io': patch
+---
+
+Change remote image scale based on fpsWatcher. Includes image memory size check.

--- a/packages/io/src/MultiscaleSpatialImage.ts
+++ b/packages/io/src/MultiscaleSpatialImage.ts
@@ -515,13 +515,8 @@ export class MultiscaleSpatialImage {
     );
   }
 
-  // indexToWorld will be undefined if getImage() not completed on scale first
-  getWorldBounds(requestedScale: number) {
-    // clap scale same as getImage for when comparing images
-    const scale = Math.min(requestedScale, this.scaleInfos.length - 1);
-    const { indexToWorld } = this.scaleInfos[scale];
-    if (!indexToWorld)
-      throw new Error('getImage() must be called before getWorldBounds()');
+  async getWorldBounds(scale: number) {
+    const indexToWorld = await this.scaleIndexToWorld(scale);
     const imageBounds = ensuredDims(
       [0, 1],
       ['x', 'y', 'z'],
@@ -538,7 +533,7 @@ export class MultiscaleSpatialImage {
 export default MultiscaleSpatialImage;
 
 // bounds defaults to whole image if undefined
-export const getVoxelCount = (
+export const getVoxelCount = async (
   image: MultiscaleSpatialImage,
   scale: number,
   bounds: Bounds | undefined = undefined,
@@ -552,8 +547,7 @@ export const getVoxelCount = (
       .reduce((voxels, dimSize) => voxels * dimSize, 1);
   }
 
-  // assumes image.scaleIndexToWorld(scale) completed to populate indexToWorld
-  const indexToWorld = image.scaleInfos[scale].indexToWorld;
+  const indexToWorld = await image.scaleIndexToWorld(scale);
   if (!indexToWorld) throw new Error('indexToWorld is undefined');
 
   const fullIndexBounds = image.getIndexBounds(scale);

--- a/packages/remote-viewport/src/remote-machine.ts
+++ b/packages/remote-viewport/src/remote-machine.ts
@@ -1,5 +1,12 @@
 import { ReadonlyMat4, mat4 } from 'gl-matrix';
-import { ActorRefFrom, assign, createMachine, raise, sendTo } from 'xstate';
+import {
+  ActorRefFrom,
+  assign,
+  createMachine,
+  fromPromise,
+  raise,
+  sendTo,
+} from 'xstate';
 import type { Image } from '@itk-wasm/htj2k';
 
 import { Viewport } from '@itk-viewer/viewer/viewport.js';
@@ -82,7 +89,8 @@ type Event =
   | SetImage
   | SlowFps
   | FastFps
-  | CameraPoseUpdated;
+  | CameraPoseUpdated
+  | { type: 'done.invoke.updateImageScale'; output: number };
 
 type ActionArgs = { event: Event; context: Context };
 
@@ -110,229 +118,268 @@ const checkTargetScaleExists = ({ event, context }: ActionArgs) => {
 };
 
 // Assumes image.scaleIndexToWorld has been called with target scale
-const checkMemory = ({ event, context }: ActionArgs) => {
+const checkMemory = async ({ event, context }: ActionArgs) => {
   const image = context.viewport.getSnapshot().context.image;
   if (!image) throw new Error('image found');
 
   const targetScale = getTargetScale({ event, context });
-  const voxelCount = getVoxelCount(image, targetScale);
+  const voxelCount = await getVoxelCount(image, targetScale);
   const imageBytes = getBytes(image, voxelCount);
 
   return imageBytes < context.maxImageBytes;
 };
 
-export const remoteMachine = createMachine(
-  {
-    types: {} as {
-      context: Context;
-      events: Event;
+export const remoteMachine = createMachine({
+  types: {} as {
+    context: Context;
+    events: Event;
+  },
+  id: 'remote',
+  context: ({ input }: { input: { viewport: Viewport } }) => ({
+    rendererProps: {
+      density: 30,
+      cameraPose: mat4.create(),
     },
-    id: 'remote',
-    context: ({ input }: { input: { viewport: Viewport } }) => ({
-      rendererProps: {
-        density: 30,
-        cameraPose: mat4.create(),
-      },
-      queuedRendererEvents: [],
-      stagedRendererEvents: [],
-      toRendererCoordinateSystem: mat4.create(),
-      maxImageBytes: MAX_IMAGE_BYTES_DEFAULT,
-      ...input, // captures injected viewport
-    }),
-    type: 'parallel',
-    states: {
-      // imageProcessor computes toRendererCoordinateSystem.
-      // Needs to be a service because MultiscaleSpatialImage.scaleIndexToWorld is async due to coords
-      imageProcessor: {
-        initial: 'idle',
-        states: {
-          idle: {
-            on: {
-              setImage: 'processing',
-            },
-          },
-          processing: {
-            invoke: {
-              id: 'imageProcessor',
-              src: 'imageProcessor',
-              input: ({ event }) => ({
-                event,
-              }),
-              onDone: {
-                actions: [
-                  assign({
-                    toRendererCoordinateSystem: ({
-                      event: {
-                        output: { toRendererCoordinateSystem },
-                      },
-                    }) => toRendererCoordinateSystem,
-                  }),
-                  raise(
-                    ({
-                      event: {
-                        output: { image },
-                      },
-                    }) => {
-                      return {
-                        type: 'updateRenderer' as const,
-                        props: {
-                          image: image.name,
-                          imageScale: image.coarsestScale,
-                        },
-                      };
-                    },
-                  ),
-                ],
-                target: 'idle',
-              },
-            },
+    queuedRendererEvents: [],
+    stagedRendererEvents: [],
+    toRendererCoordinateSystem: mat4.create(),
+    maxImageBytes: MAX_IMAGE_BYTES_DEFAULT,
+    ...input, // captures injected viewport
+  }),
+  type: 'parallel',
+  states: {
+    // imageProcessor computes toRendererCoordinateSystem.
+    // Is an actor because MultiscaleSpatialImage.scaleIndexToWorld is async due to coords
+    imageProcessor: {
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            setImage: 'processing',
           },
         },
-      },
-      // root state captures initial rendererProps even when disconnected
-      root: {
-        entry: [
-          assign({
-            viewport: ({ spawn }) => spawn(viewportMachine, { id: 'viewport' }),
-          }),
-        ],
-        on: {
-          updateRenderer: {
-            actions: [
-              assign({
-                rendererProps: ({ event: { props }, context }) => {
-                  return {
-                    ...context.rendererProps,
-                    ...props,
-                  };
-                },
-                queuedRendererEvents: ({ event: { props }, context }) => [
-                  ...context.queuedRendererEvents,
-                  ...(getEntries(props) as RendererEntries),
-                ],
-              }),
-              // Trigger a render (if in idle state)
-              raise({ type: 'render' }),
-            ],
-          },
-          cameraPoseUpdated: {
-            actions: [
-              raise(({ event }) => {
-                return {
-                  type: 'updateRenderer' as const,
-                  props: { cameraPose: event.pose },
-                };
-              }),
-            ],
-          },
-        },
-        initial: 'disconnected',
-        states: {
-          disconnected: {
-            on: {
-              connect: {
-                actions: [
-                  assign({
-                    serverConfig: ({
-                      event: { config },
-                    }: {
-                      event: ConnectEvent;
-                    }) => {
-                      return config;
+        processing: {
+          invoke: {
+            id: 'imageProcessor',
+            src: 'imageProcessor',
+            input: ({ event }) => ({
+              event,
+            }),
+            onDone: {
+              actions: [
+                assign({
+                  toRendererCoordinateSystem: ({
+                    event: {
+                      output: { toRendererCoordinateSystem },
                     },
-                  }),
-                ],
-                target: 'connecting',
-              },
-            },
-          },
-          connecting: {
-            invoke: {
-              id: 'connect',
-              src: 'connect',
-              input: ({ context }: { context: Context }) => ({
-                context,
-              }),
-              onDone: {
-                actions: assign({
-                  server: ({ event }) => event.output,
-                  // initially, send all props to renderer
-                  queuedRendererEvents: ({ context }) =>
-                    getEntries(context.rendererProps),
+                  }) => toRendererCoordinateSystem,
                 }),
-                target: 'online',
-              },
+                raise(
+                  ({
+                    event: {
+                      output: { image },
+                    },
+                  }) => {
+                    return {
+                      type: 'updateRenderer' as const,
+                      props: {
+                        image: image.name,
+                        imageScale: image.coarsestScale,
+                      },
+                    };
+                  },
+                ),
+              ],
+              target: 'idle',
             },
           },
-          online: {
-            on: {
-              slowFps: {
-                actions: ['updateImageScale'],
+        },
+      },
+    },
+    // root state captures initial rendererProps events even when disconnected
+    root: {
+      entry: [
+        assign({
+          viewport: ({ spawn }) => spawn(viewportMachine, { id: 'viewport' }),
+        }),
+      ],
+      on: {
+        updateRenderer: {
+          actions: [
+            assign({
+              rendererProps: ({ event: { props }, context }) => {
+                return {
+                  ...context.rendererProps,
+                  ...props,
+                };
               },
-              fastFps: {
-                actions: ['updateImageScale'],
+              queuedRendererEvents: ({ event: { props }, context }) => [
+                ...context.queuedRendererEvents,
+                ...(getEntries(props) as RendererEntries),
+              ],
+            }),
+            // Trigger a render (if in idle state)
+            raise({ type: 'render' }),
+          ],
+        },
+        cameraPoseUpdated: {
+          actions: [
+            raise(({ event }) => {
+              return {
+                type: 'updateRenderer' as const,
+                props: { cameraPose: event.pose },
+              };
+            }),
+          ],
+        },
+      },
+      initial: 'disconnected',
+      states: {
+        disconnected: {
+          on: {
+            connect: {
+              actions: [
+                assign({
+                  serverConfig: ({
+                    event: { config },
+                  }: {
+                    event: ConnectEvent;
+                  }) => {
+                    return config;
+                  },
+                }),
+              ],
+              target: 'connecting',
+            },
+          },
+        },
+        connecting: {
+          invoke: {
+            id: 'connect',
+            src: 'connect',
+            input: ({ context, event }) => ({
+              context,
+              event,
+            }),
+            onDone: {
+              actions: assign({
+                server: ({ event }) => event.output,
+                // initially, send all props to renderer
+                queuedRendererEvents: ({ context }) =>
+                  getEntries(context.rendererProps),
+              }),
+              target: 'online',
+            },
+          },
+        },
+        online: {
+          type: 'parallel',
+          states: {
+            fpsWatcher: {
+              invoke: {
+                id: 'fpsWatcher',
+                src: fpsWatcher,
               },
             },
-            type: 'parallel',
-            states: {
-              fpsWatcher: {
-                invoke: {
-                  id: 'fpsWatcher',
-                  src: fpsWatcher,
+            imageScaleUpdater: {
+              on: {
+                slowFps: {
+                  target: '.updatingScale',
+                },
+                fastFps: {
+                  target: '.updatingScale',
                 },
               },
-              renderLoop: {
-                initial: 'render',
-                states: {
-                  render: {
-                    invoke: {
-                      id: 'render',
-                      src: 'renderer',
-                      input: ({ context }: { context: Context }) => ({
-                        events: [...context.stagedRendererEvents],
-                        context,
-                      }),
-                      onDone: {
-                        actions: [
-                          assign({
-                            frame: ({ event }) => {
-                              return event.output.frame;
-                            },
-                          }),
-                          sendTo('fpsWatcher', ({ event }) => ({
-                            type: 'newSample',
-                            renderTime: event.output.renderTime,
-                          })),
-                        ],
-                        target: 'idle',
-                      },
-                      onError: {
-                        actions: (e) =>
-                          console.error(
-                            `Error while updating render: ${e.event.data}`,
-                          ),
-                        target: 'idle', // soldier on
-                      },
-                    },
-                  },
-                  idle: {
-                    always: {
-                      // Renderer props changed while rendering? Then render.
-                      guard: ({ context }) =>
-                        context.queuedRendererEvents.length > 0,
-                      target: 'render',
-                    },
-                    on: {
-                      render: { target: 'render' },
-                    },
-                    exit: assign({
-                      // consumes queue in prep for renderer
-                      stagedRendererEvents: ({ context }) => [
-                        ...context.queuedRendererEvents,
-                      ],
-                      queuedRendererEvents: [],
+              initial: 'idle',
+              states: {
+                idle: {},
+                updatingScale: {
+                  invoke: {
+                    id: 'updateImageScale',
+                    input: ({ context, event }) => ({
+                      context,
+                      event,
                     }),
+                    src: fromPromise(async ({ input: { event, context } }) => {
+                      const image =
+                        context.viewport.getSnapshot().context.image;
+                      if (!image) return; // may be rendering without image
+
+                      if (!checkTargetScaleExists({ event, context })) return;
+                      if (!(await checkMemory({ event, context }))) return;
+
+                      return getTargetScale({ event, context });
+                    }),
+                    onDone: {
+                      guard: ({ event }) => event.output !== undefined,
+                      target: 'raiseImageScale',
+                    },
                   },
+                },
+                raiseImageScale: {
+                  entry: raise(({ event }) => {
+                    if (event.type !== 'done.invoke.updateImageScale')
+                      throw new Error('Unexpected event type');
+                    return {
+                      type: 'updateRenderer' as const,
+                      props: { imageScale: event.output },
+                    };
+                  }),
+                },
+              },
+            },
+            renderLoop: {
+              initial: 'render',
+              states: {
+                render: {
+                  invoke: {
+                    id: 'render',
+                    src: 'renderer',
+                    input: ({ context }: { context: Context }) => ({
+                      events: [...context.stagedRendererEvents],
+                      context,
+                    }),
+                    onDone: {
+                      actions: [
+                        assign({
+                          frame: ({ event }) => {
+                            return event.output.frame;
+                          },
+                        }),
+                        sendTo('fpsWatcher', ({ event }) => ({
+                          type: 'newSample',
+                          renderTime: event.output.renderTime,
+                        })),
+                      ],
+                      target: 'idle',
+                    },
+                    onError: {
+                      actions: (e) =>
+                        console.error(
+                          `Error while updating render.`,
+                          e.event.data,
+                        ),
+                      target: 'idle', // soldier on
+                    },
+                  },
+                },
+                idle: {
+                  always: {
+                    // Renderer props changed while rendering? Then render.
+                    guard: ({ context }) =>
+                      context.queuedRendererEvents.length > 0,
+                    target: 'render',
+                  },
+                  on: {
+                    render: { target: 'render' },
+                  },
+                  exit: assign({
+                    // consumes queue in prep for renderer
+                    stagedRendererEvents: ({ context }) => [
+                      ...context.queuedRendererEvents,
+                    ],
+                    queuedRendererEvents: [],
+                  }),
                 },
               },
             },
@@ -341,24 +388,4 @@ export const remoteMachine = createMachine(
       },
     },
   },
-  {
-    actions: {
-      updateImageScale: ({ event, context, self }) => {
-        const image = context.viewport.getSnapshot().context.image;
-        if (!image) return; // may be rendering without image
-
-        if (context.rendererProps.imageScale === undefined)
-          throw new Error('imageScale not found');
-
-        if (!checkTargetScaleExists({ event, context })) return;
-        if (!checkMemory({ event, context })) return;
-
-        const targetScale = getTargetScale({ event, context });
-        self.send({
-          type: 'updateRenderer',
-          props: { imageScale: targetScale },
-        });
-      },
-    },
-  },
-);
+});

--- a/packages/remote-viewport/src/remote-viewport.ts
+++ b/packages/remote-viewport/src/remote-viewport.ts
@@ -140,20 +140,14 @@ export const createHyphaMachineConfig: () => RemoteMachineOptions = () => {
           return { frame, renderTime };
         },
       ),
+      // compute toRendererCoordinateSystem
       imageProcessor: fromPromise(
         async ({
           input: {
             event: { image },
           },
         }) => {
-          // initializes indexToWorld matrix for getWorldBounds and checkMemory guard
-          for (let i = 0; i < image.scaleInfos.length; i++) {
-            await image.scaleIndexToWorld(i);
-          }
-
-          // compute toRendererCoordinateSystem
-          const imageScale = image.coarsestScale;
-          const bounds = image.getWorldBounds(imageScale);
+          const bounds = await image.getWorldBounds(image.coarsestScale);
 
           // match Agave by normalizing to largest dim
           const wx = bounds[1] - bounds[0];

--- a/packages/viewer/src/camera-machine.ts
+++ b/packages/viewer/src/camera-machine.ts
@@ -7,9 +7,10 @@ export type LookAtParams = {
   up: ReadonlyVec3;
 };
 
-type context = {
+type Context = {
   pose: ReadonlyMat4;
   lookAt: LookAtParams;
+  verticalFieldOfView: number;
 };
 
 type SetPoseEvent = {
@@ -24,7 +25,7 @@ type LookAtEvent = {
 
 const cameraMachine = createMachine({
   types: {} as {
-    context: context;
+    context: Context;
     events: SetPoseEvent | LookAtEvent;
   },
   id: 'camera',
@@ -32,6 +33,7 @@ const cameraMachine = createMachine({
   context: {
     pose: mat4.create(),
     lookAt: { eye: [0, 0, 0], target: [0, 0, 1], up: [0, 1, 0] },
+    verticalFieldOfView: 50,
   },
   states: {
     active: {

--- a/packages/viewer/src/viewport-machine.ts
+++ b/packages/viewer/src/viewport-machine.ts
@@ -93,9 +93,10 @@ export const viewportMachine = createMachine(
       resetCameraPose: async ({ context: { image, camera } }) => {
         if (!image || !camera) return;
 
-        const scale = image.coarsestScale;
-        await image.scaleIndexToWorld(scale); // initializes indexToWorld matrix for getWorldBounds
-        const bounds = image.getWorldBounds(scale);
+        const { pose: currentPose, verticalFieldOfView } =
+          camera.getSnapshot().context;
+
+        const bounds = await image.getWorldBounds(image.coarsestScale);
 
         const center = vec3.fromValues(
           (bounds[0] + bounds[1]) / 2.0,
@@ -115,10 +116,8 @@ export const viewportMachine = createMachine(
         // compute the radius of the enclosing sphere
         radius = Math.sqrt(radius) * 0.5;
 
-        const angle = 55 * (Math.PI / 180); // to radians
+        const angle = verticalFieldOfView * (Math.PI / 180); // to radians
         const distance = radius / Math.sin(angle * 0.5);
-
-        const currentPose = camera.getSnapshot().context.pose;
 
         const forward = [currentPose[8], currentPose[9], currentPose[10]];
         const up = vec3.fromValues(


### PR DESCRIPTION
Computed properties like getVoxelCount which depend on async MultiscaleSpatialImage.scaleIndexToWorld() should be async as well.