### PR TITLE
Remote Viewport Performance Impovements

### DIFF
--- a/.changeset/dry-pigs-flow.md
+++ b/.changeset/dry-pigs-flow.md
@@ -1,0 +1,7 @@
+---
+'@itk-viewer/remote-viewport': patch
+'@itk-viewer/element': patch
+'@itk-viewer/viewer': patch
+---
+
+Performance improvements to canvas blitting and render loop

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "pnpm -r --parallel run dev",
+    "dev:debug": "VITE_DEBUG=true pnpm -r --parallel run dev",
     "build": "pnpm -r build",
     "lint": "pnpm prettier --check . && pnpm eslint .",
     "lint:fix": "pnpm prettier --write . && pnpm eslint --fix .",

--- a/packages/element/.env.example
+++ b/packages/element/.env.example
@@ -1,4 +1,4 @@
-VITE_HYPHA_URL=https://my-hypha-instance.com
-VITE_HYPHA_RENDER_SERVICE_ID=test-agave-renderer
+VITE_HYPHA_URL=http://127.0.0.1:9000
+VITE_HYPHA_RENDER_SERVICE_ID=agave-renderer-rtc
 VITE_HYPHA_REMOTE_ZARR_SERVICE_ID=remote-zarr
 VITE_IMAGE=data/aneurism.ome.tif

--- a/packages/element/src/itk-remote-viewport.ts
+++ b/packages/element/src/itk-remote-viewport.ts
@@ -179,7 +179,7 @@ export class ItkRemoteViewport extends ItkViewport {
     if (changedProperties.has('density')) {
       this.remote.send({
         type: 'updateRenderer',
-        props: { density: this.density },
+        state: { density: this.density },
       });
     }
 

--- a/packages/element/src/itk-remote-viewport.ts
+++ b/packages/element/src/itk-remote-viewport.ts
@@ -40,6 +40,8 @@ export class ItkRemoteViewport extends ItkViewport {
   frame: SelectorController<RemoteActor, Image | undefined>;
   lastFrameValue: Image | undefined = undefined;
 
+  frameData: ImageData | undefined = undefined;
+
   bounds: SelectorController<
     RemoteActor,
     {
@@ -117,13 +119,19 @@ export class ItkRemoteViewport extends ItkViewport {
     const { size, data } = this.frame.value;
     if (!data) throw new Error('No data in frame');
     const [width, height] = size;
-    if (this.canvas.value) {
-      this.canvas.value.width = width;
-      this.canvas.value.height = height;
+
+    // Cache ImageData to avoid allocation
+    if (
+      !this.frameData ||
+      this.frameData.width !== width ||
+      this.frameData.height !== height
+    ) {
+      this.canvas.value!.width = width;
+      this.canvas.value!.height = height;
+      this.frameData = this.canvasCtx.createImageData(width, height);
     }
-    const pixels = new Uint8ClampedArray(data);
-    const imageData = new ImageData(pixels, width, height);
-    this.canvasCtx.putImageData(imageData, 0, 0);
+    this.frameData.data.set(data as ArrayLike<number>);
+    this.canvasCtx.putImageData(this.frameData, 0, 0);
   }
 
   startRenderLoop() {

--- a/packages/remote-viewport/src/remote-machine.ts
+++ b/packages/remote-viewport/src/remote-machine.ts
@@ -27,7 +27,7 @@ import {
 
 const MAX_IMAGE_BYTES_DEFAULT = 4000 * 1000 * 1000; // 4000 MB
 
-type RendererProps = {
+type RendererState = {
   density: number;
   cameraPose: ReadonlyMat4;
   renderSize: [number, number];
@@ -45,15 +45,15 @@ const getEntries = <T extends object>(obj: T) =>
   Object.entries(obj) as Entries<T>;
 
 // example: [['density', 30], ['cameraPose', mat4.create()]]
-export type RendererEntries = Entries<RendererProps>;
+export type RendererEntries = Entries<RendererState>;
 
 export type Context = {
   serverConfig?: unknown;
   server?: unknown;
   frame?: Image;
-  rendererProps: RendererProps;
-  queuedRendererEvents: RendererEntries;
-  stagedRendererEvents: RendererEntries;
+  rendererState: RendererState;
+  queuedRendererCommands: RendererEntries;
+  stagedRendererCommands: RendererEntries;
   viewport: ActorRefFrom<typeof viewportMachine>;
   maxImageBytes: number;
   // computed image values
@@ -71,7 +71,7 @@ type ConnectEvent = {
 
 type UpdateRendererEvent = {
   type: 'updateRenderer';
-  props: Partial<RendererProps>;
+  state: Partial<RendererState>;
 };
 
 type RenderEvent = {
@@ -136,10 +136,10 @@ const getImage = (context: Context) => {
 
 const getTargetScale = ({ event, context }: ActionArgs) => {
   const image = getImage(context);
-  if (context.rendererProps.imageScale === undefined)
+  if (context.rendererState.imageScale === undefined)
     throw new Error('imageScale not found');
 
-  const currentScale = context.rendererProps.imageScale;
+  const currentScale = context.rendererState.imageScale;
   const scaleChange = event.type === 'slowFps' ? 1 : -1;
   const targetScale = currentScale + scaleChange;
   return Math.max(0, Math.min(image.coarsestScale, targetScale));
@@ -160,14 +160,14 @@ export const remoteMachine = createMachine({
   },
   id: 'remote',
   context: ({ input }: { input: { viewport: Viewport } }) => ({
-    rendererProps: {
+    rendererState: {
       density: 30,
       cameraPose: mat4.create(),
       renderSize: [1, 1] as [number, number],
       normalizedClipBounds: [0, 1, 0, 1, 0, 1] as Bounds,
     },
-    queuedRendererEvents: [],
-    stagedRendererEvents: [],
+    queuedRendererCommands: [],
+    stagedRendererCommands: [],
 
     // computed async image values
     toRendererCoordinateSystem: mat4.create(),
@@ -208,7 +208,7 @@ export const remoteMachine = createMachine({
             src: fromPromise(async ({ input: { imageScale, context } }) => {
               const image = getImage(context);
 
-              if (imageScale === context.rendererProps.imageScale) return;
+              if (imageScale === context.rendererState.imageScale) return;
 
               const imageBytes = await computeBytes(image, imageScale);
               if (imageBytes > context.maxImageBytes) return;
@@ -260,7 +260,7 @@ export const remoteMachine = createMachine({
         checkingFirstImage: {
           always: [
             {
-              guard: ({ context }) => context.rendererProps.image === undefined,
+              guard: ({ context }) => context.rendererState.image === undefined,
               target: 'initClipBounds',
             },
             { target: 'sendingToRenderer' },
@@ -281,7 +281,7 @@ export const remoteMachine = createMachine({
             const { image, imageScale } = (event as ImageProcessorDone).output;
             return {
               type: 'updateRenderer' as const,
-              props: {
+              state: {
                 image: image.name,
                 imageScale,
               },
@@ -290,7 +290,7 @@ export const remoteMachine = createMachine({
         },
       },
     },
-    // root state captures initial rendererProps events even when disconnected
+    // root state captures initial updateRenderer events, even when disconnected
     root: {
       entry: [
         assign({
@@ -301,15 +301,15 @@ export const remoteMachine = createMachine({
         updateRenderer: {
           actions: [
             assign({
-              rendererProps: ({ event: { props }, context }) => {
+              rendererState: ({ event: { state }, context }) => {
                 return {
-                  ...context.rendererProps,
-                  ...props,
+                  ...context.rendererState,
+                  ...state,
                 };
               },
-              queuedRendererEvents: ({ event: { props }, context }) => [
-                ...context.queuedRendererEvents,
-                ...(getEntries(props) as RendererEntries),
+              queuedRendererCommands: ({ event: { state }, context }) => [
+                ...context.queuedRendererCommands,
+                ...(getEntries(state) as RendererEntries),
               ],
             }),
             // Trigger a render (if in idle state)
@@ -321,7 +321,7 @@ export const remoteMachine = createMachine({
             raise(({ event }) => {
               return {
                 type: 'updateRenderer' as const,
-                props: { cameraPose: event.pose },
+                state: { cameraPose: event.pose },
               };
             }),
           ],
@@ -331,7 +331,7 @@ export const remoteMachine = createMachine({
             raise(({ event }) => {
               return {
                 type: 'updateRenderer' as const,
-                props: { renderSize: event.resolution },
+                state: { renderSize: event.resolution },
               };
             }),
           ],
@@ -347,11 +347,11 @@ export const remoteMachine = createMachine({
                   viewport,
                   clipBounds,
                   imageWorldToIndex,
-                  rendererProps,
+                  rendererState,
                 },
                 event,
               }) => {
-                const imageScale = event.imageScale ?? rendererProps.imageScale;
+                const imageScale = event.imageScale ?? rendererState.imageScale;
                 const { image } = viewport.getSnapshot().context;
                 if (!image || imageScale === undefined)
                   throw new Error('image or imageScale not found');
@@ -378,7 +378,7 @@ export const remoteMachine = createMachine({
 
                 return {
                   type: 'updateRenderer' as const,
-                  props: { normalizedClipBounds },
+                  state: { normalizedClipBounds },
                 };
               },
             ),
@@ -416,9 +416,9 @@ export const remoteMachine = createMachine({
             onDone: {
               actions: assign({
                 server: ({ event }) => event.output,
-                // initially, send all props to renderer
-                queuedRendererEvents: ({ context }) =>
-                  getEntries(context.rendererProps),
+                // initially, send all commands to renderer
+                queuedRendererCommands: ({ context }) =>
+                  getEntries(context.rendererState),
               }),
               target: 'online',
             },
@@ -453,19 +453,18 @@ export const remoteMachine = createMachine({
                 },
               },
             },
-            sendPropsLoop: {
-              initial: 'sendingProps',
+            commandLoop: {
+              initial: 'sendingCommands',
               states: {
-                sendingProps: {
+                sendingCommands: {
                   invoke: {
-                    id: 'propSender',
-                    src: 'propSender',
+                    id: 'commandSender',
+                    src: 'commandSender',
                     input: ({ context }: { context: Context }) => ({
-                      events: [...context.stagedRendererEvents],
+                      commands: [...context.stagedRendererCommands],
                       context,
                     }),
                     onDone: {
-                      actions: [],
                       target: 'idle',
                     },
                     onError: {
@@ -480,20 +479,20 @@ export const remoteMachine = createMachine({
                 },
                 idle: {
                   always: {
-                    // Renderer props changed while sending commands? Then sendCommands.
+                    // More commands while sending commands? Then send commands.
                     guard: ({ context }) =>
-                      context.queuedRendererEvents.length > 0,
-                    target: 'sendingProps',
+                      context.queuedRendererCommands.length > 0,
+                    target: 'sendingCommands',
                   },
                   on: {
-                    sendCommands: { target: 'sendingProps' },
+                    sendCommands: { target: 'sendingCommands' },
                   },
                   exit: assign({
                     // consumes queue in prep for renderer
-                    stagedRendererEvents: ({ context }) => [
-                      ...context.queuedRendererEvents,
+                    stagedRendererCommands: ({ context }) => [
+                      ...context.queuedRendererCommands,
                     ],
-                    queuedRendererEvents: [],
+                    queuedRendererCommands: [],
                   }),
                 },
               },

--- a/packages/remote-viewport/src/remote-viewport.ts
+++ b/packages/remote-viewport/src/remote-viewport.ts
@@ -89,7 +89,7 @@ export const createHyphaMachineConfig: () => RemoteMachineOptions = () => {
       connect: fromPromise(async ({ input }: { input: ConnectInput }) =>
         createHyphaRenderer(input.context),
       ),
-      renderer: fromPromise(
+      propSender: fromPromise(
         async ({ input: { context, events } }: { input: RendererInput }) => {
           const commands = events
             .map(([key, value]) => {
@@ -135,8 +135,15 @@ export const createHyphaMachineConfig: () => RemoteMachineOptions = () => {
               return [event];
             });
 
-          const { server } = context;
-          server.updateRenderer(commands);
+          context.server.updateRenderer(commands);
+        },
+      ),
+      renderer: fromPromise(
+        async ({
+          input: {
+            context: { server },
+          },
+        }) => {
           const { frame: encodedImage, renderTime } = await server.render();
           const { image: frame, webWorker } = await decode(
             decodeWorker,

--- a/packages/remote-viewport/src/remote-viewport.ts
+++ b/packages/remote-viewport/src/remote-viewport.ts
@@ -23,7 +23,7 @@ type MachineContext = Omit<Context, 'server'> & { server: Renderer };
 
 type RendererInput = {
   context: MachineContext;
-  events: RendererEntries;
+  commands: RendererEntries;
 };
 
 type ConnectInput = { context: Context };
@@ -89,9 +89,9 @@ export const createHyphaMachineConfig: () => RemoteMachineOptions = () => {
       connect: fromPromise(async ({ input }: { input: ConnectInput }) =>
         createHyphaRenderer(input.context),
       ),
-      propSender: fromPromise(
-        async ({ input: { context, events } }: { input: RendererInput }) => {
-          const commands = events
+      commandSender: fromPromise(
+        async ({ input: { context, commands } }: { input: RendererInput }) => {
+          const translatedCommands = commands
             .map(([key, value]) => {
               if (key === 'cameraPose') {
                 return makeCameraPoseCommand(
@@ -102,7 +102,7 @@ export const createHyphaMachineConfig: () => RemoteMachineOptions = () => {
 
               if (key === 'image') {
                 const { imageScale: multiresolution_level } =
-                  context.rendererProps;
+                  context.rendererState;
                 return [
                   'loadImage',
                   { image_path: value, multiresolution_level },
@@ -110,7 +110,7 @@ export const createHyphaMachineConfig: () => RemoteMachineOptions = () => {
               }
 
               if (key === 'imageScale') {
-                const { image: image_path } = context.rendererProps;
+                const { image: image_path } = context.rendererState;
                 return [
                   'loadImage',
                   { image_path, multiresolution_level: value },
@@ -128,14 +128,14 @@ export const createHyphaMachineConfig: () => RemoteMachineOptions = () => {
                   event,
                   makeCameraPoseCommand(
                     context.toRendererCoordinateSystem,
-                    context.rendererProps.cameraPose,
+                    context.rendererState.cameraPose,
                   ),
                 ];
               }
               return [event];
             });
 
-          context.server.updateRenderer(commands);
+          context.server.updateRenderer(translatedCommands);
         },
       ),
       renderer: fromPromise(

--- a/packages/viewer/src/fps-watcher-machine.ts
+++ b/packages/viewer/src/fps-watcher-machine.ts
@@ -1,5 +1,7 @@
 import { assign, createMachine, sendParent } from 'xstate';
 
+const DEBUG = Boolean(import.meta.env.VITE_DEBUG ?? false);
+
 const SAMPLE_SIZE = 30;
 
 const SLOW_FPS = 15;
@@ -43,8 +45,11 @@ export const fpsWatcher = createMachine(
       judge: {
         entry: [
           assign({
-            average: ({ context: { samples } }) =>
-              samples.reduce((a, b) => a + b) / samples.length,
+            average: ({ context: { samples } }) => {
+              const average = samples.reduce((a, b) => a + b) / samples.length;
+              if (DEBUG) console.log('FPS Watcher Average:', average);
+              return average;
+            },
           }),
         ],
         always: [

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "declaration": true,
     "composite": true,
-    "types": [
-      "vite/client"
-    ]
+    "types": ["vite/client"]
   },
   "exclude": [
     "packages/**/dist/",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,7 +2,10 @@
   "extends": "./tsconfig.root",
   "compilerOptions": {
     "declaration": true,
-    "composite": true
+    "composite": true,
+    "types": [
+      "vite/client"
+    ]
   },
   "exclude": [
     "packages/**/dist/",


### PR DESCRIPTION
- Cache ImageData for less allocations.  Speeds up putFrame from ~8ms to ~1.5ms for 1920 x 1080.
- Add VITE_DEBUG env var for console.log
- Independent sendProps and render loops