### PR TITLE
chore(package): publish packages public on first release

### DIFF
--- a/.changeset/gentle-worms-boil.md
+++ b/.changeset/gentle-worms-boil.md
@@ -1,0 +1,5 @@
+---
+'@itk-viewer/vtkjs': patch
+---
+
+Trigger a publish to fix private publish attempt.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
   version:
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: checkout code repository
         uses: actions/checkout@v3
@@ -41,3 +43,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cy:component:ci": "cypress run --component --record",
     "cy:component:chrome": "cypress run --component --browser chrome",
     "clean": "git clean -fdx",
-    "ci:publish": "pnpm publish -r"
+    "ci:publish": "pnpm publish -r --access public"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.2",


### PR DESCRIPTION
Scoped packages (ie @itk-viewer/vtkjs) are published private by default.  We want public.

Also adds npm provenance config to release.yml
https://docs.npmjs.com/generating-provenance-statements