### PR TITLE
feat(itk-remote-viewport): add WebRTC video

### DIFF
--- a/packages/agave-renderer/itk_viewer_agave_renderer/renderer.py
+++ b/packages/agave-renderer/itk_viewer_agave_renderer/renderer.py
@@ -13,9 +13,38 @@ from itkwasm import Image, ImageType, PixelTypes, IntTypes
 import numpy as np
 from PIL import Image as PILImage
 
+import fractions
+from av import VideoFrame
+from aiortc import MediaStreamTrack
+
 # Should match constant in connected clients.
 # The WebRTC service id is different from this
 RENDERER_SERVICE_ID = "agave-renderer"
+
+class VideoTransformTrack(MediaStreamTrack):
+    """
+    A video stream track that transforms frames from an another track.
+    """
+
+    kind = "video"
+
+    def __init__(self, get_frame):
+        super().__init__()  # don't forget this!
+        self.count = 0
+        self.get_frame = get_frame
+
+    async def recv(self):
+        # frame = await self.track.recv()
+        img = await self.get_frame()
+        img = img or PILImage.new("RGBA", (1, 1))
+
+        frame = VideoFrame.from_image(img)
+
+        frame.pts = self.count 
+        self.count+=1
+        frame.time_base = fractions.Fraction(1, 1000)
+        return frame
+
 
 
 class AgaveRendererMemoryRedraw(agave.AgaveRenderer):
@@ -32,8 +61,7 @@ class AgaveRendererMemoryRedraw(agave.AgaveRenderer):
         # ready for next frame
         self.cb = agave.commandbuffer.CommandBuffer()
         img = PILImage.open(binarydata)
-        rgba = img.convert("RGBA").tobytes()
-        return rgba
+        return img
 
 
 # how to handle unknown events
@@ -50,6 +78,8 @@ class Renderer:
         self.width = width
         self.height = height
         self.unknown_event_action = unknown_event_action
+        self.render_time = .1
+        self.agave = None
 
     async def setup(self):
         # Note: the agave websocket server needs to be running
@@ -80,10 +110,23 @@ class Renderer:
         self.height = height
         self.agave.set_resolution(width, height)
 
-    async def render(self):
+    async def draw_frame(self):
+        if self.agave is None:
+            return
         r = self.agave
         start_time = time.time()
-        rgba = r.memory_redraw()
+        img = r.memory_redraw()
+        self.render_time = time.time() - start_time
+        return img
+    
+    def get_render_time(self):
+        return self.render_time
+
+    async def render(self):
+        if self.agave is None:
+            return
+        frame = await self.draw_frame()
+        rgba = frame.convert("RGBA").tobytes()
         image_type = ImageType(
             dimension=2,
             componentType=IntTypes.UInt8,
@@ -95,8 +138,7 @@ class Renderer:
         image.data = np.frombuffer(rgba, dtype=np.uint8)
         # rgba_encoded = encode(image) # lossless
         rgba_encoded = encode(image, not_reversible=True, quantization_step=0.02)
-        elapsed = time.time() - start_time
-        return {"frame": rgba_encoded, "renderTime": elapsed}
+        return {"frame": rgba_encoded, 'renderTime': self.render_time}
 
     async def update_renderer(self, events):
         r = self.agave
@@ -132,6 +174,18 @@ class Renderer:
             case UnknownEventAction.IGNORE:
                 pass
 
+
+    async def on_init(self, peer_connection):
+        @peer_connection.on("track")
+        def on_track(track):
+            print(f"Track {track.kind} received")
+            peer_connection.addTrack(
+                VideoTransformTrack(self.draw_frame)
+            )
+            @track.on("ended")
+            async def on_ended():
+                print(f"Track {track.kind} ended")
+
     async def connect(
         self,
         hypha_server_url,
@@ -161,6 +215,7 @@ class Renderer:
                 "setup": self.setup,
                 "loadImage": self.load_image,
                 "render": self.render,
+                "getRenderTime": self.get_render_time,
                 "updateRenderer": self.update_renderer,
             }
         )
@@ -170,6 +225,7 @@ class Renderer:
             service_id=service_id,
             config={
                 "visibility": "public",
+                "on_init": self.on_init,
             },
         )
 

--- a/packages/agave-renderer/itk_viewer_agave_renderer/renderer.py
+++ b/packages/agave-renderer/itk_viewer_agave_renderer/renderer.py
@@ -178,13 +178,12 @@ class Renderer:
     async def on_init(self, peer_connection):
         @peer_connection.on("track")
         def on_track(track):
-            print(f"Track {track.kind} received")
             peer_connection.addTrack(
                 VideoTransformTrack(self.draw_frame)
             )
             @track.on("ended")
             async def on_ended():
-                print(f"Track {track.kind} ended")
+                pass
 
     async def connect(
         self,

--- a/packages/element/examples/remote-webrtc.html
+++ b/packages/element/examples/remote-webrtc.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>itk-viewer</title>
+    <link rel="stylesheet" href="../src/index.css" />
+    <script type="module" src="../src/itk-remote-viewport-webrtc.ts"></script>
+    <script type="module" src="../src/itk-viewer-element.ts"></script>
+    <script type="module" src="./remote-webrtc.ts"></script>
+  </head>
+
+  <body>
+    <itk-viewer class="fill">
+      <itk-remote-viewport-webrtc
+        class="fill"
+        id="right-viewport"
+        server-config='{ "serverUrl": "%VITE_HYPHA_URL%", "serviceId": "%VITE_HYPHA_RENDER_SERVICE_ID%" }'
+      ></itk-remote-viewport-webrtc>
+    </itk-viewer>
+  </body>
+</html>

--- a/packages/element/examples/remote-webrtc.ts
+++ b/packages/element/examples/remote-webrtc.ts
@@ -1,0 +1,21 @@
+import { makeZarrImage } from '@itk-viewer/remote-viewport/remote-image.js';
+
+const viewport = document.querySelector('itk-remote-viewport-webrtc');
+if (!viewport) throw new Error('Could not find element');
+
+const serverUrl = import.meta.env.VITE_HYPHA_URL;
+const remoteZarrServiceId = import.meta.env.VITE_HYPHA_REMOTE_ZARR_SERVICE_ID;
+
+const imagePath = import.meta.env.VITE_IMAGE;
+
+const setImage = async (imagePath: string) => {
+  const image = await makeZarrImage({
+    imagePath,
+    serverUrl,
+    serviceId: remoteZarrServiceId,
+  });
+  viewport.viewport.send({ type: 'setImage', image });
+  viewport.remote.send({ type: 'imageAssigned', image });
+};
+
+setImage(imagePath);

--- a/packages/element/src/itk-remote-viewport-webrtc.ts
+++ b/packages/element/src/itk-remote-viewport-webrtc.ts
@@ -1,0 +1,289 @@
+/// <reference types="vite/client" />
+import { PropertyValues, css, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import { Ref, createRef, ref } from 'lit/directives/ref.js';
+import { SelectorController } from 'xstate-lit';
+import { ActorRefFrom } from 'xstate';
+
+import {
+  RemoteActor,
+  createHyphaMachineConfig,
+  createRemoteViewport,
+} from '@itk-viewer/remote-viewport/remote-viewport.js';
+
+import type { Image } from '@itk-viewer/remote-viewport/remote-viewport.js';
+
+import { ItkViewport } from './itk-viewport.js';
+import './itk-camera.js';
+import { Bounds } from '@itk-viewer/io/types.js';
+import { chunk } from '@itk-viewer/io/dimensionUtils.js';
+import { viewportMachine } from '@itk-viewer/viewer/viewport.js';
+
+@customElement('itk-remote-viewport-webrtc')
+export class ItkRemoteViewport extends ItkViewport {
+  @property({ type: Object, attribute: 'server-config' })
+  serverConfig: unknown | undefined;
+
+  @property({ type: Number })
+  density = 30;
+
+  camera: Ref<HTMLElement> = createRef();
+
+  viewport: ActorRefFrom<typeof viewportMachine>;
+  remote: RemoteActor;
+
+  remoteOnline: SelectorController<RemoteActor, boolean>;
+  lastRemoteOnlineValue = false;
+  renderLoopRunning = false;
+
+  canvas: Ref<HTMLVideoElement> = createRef();
+  frame: SelectorController<RemoteActor, Image | undefined>;
+  lastFrameValue: Image | undefined = undefined;
+  frameData: ImageData | undefined = undefined;
+
+  hostCanvas = document.createElement('canvas');
+  peerConnection: RTCPeerConnection | undefined = undefined;
+
+  bounds: SelectorController<
+    RemoteActor,
+    {
+      imageWorldBounds: Bounds;
+      clipBounds: Bounds;
+      clipBoundsWithNormalized: Array<readonly [number, number]>;
+    }
+  >;
+
+  cleanDimension = (v: number) => Math.max(1, Math.floor(v));
+
+  private resizer = new ResizeObserver(
+    (entries: Array<ResizeObserverEntry>) => {
+      if (!entries.length) return;
+
+      const { width, height } = entries[0].contentRect;
+      const resolution = [width, height].map(this.cleanDimension) as [
+        number,
+        number,
+      ];
+
+      this.viewport.send({
+        type: 'setResolution',
+        resolution,
+      });
+    },
+  );
+
+  constructor() {
+    super();
+    const { remote, viewport } = createRemoteViewport(
+      createHyphaMachineConfig((pc: RTCPeerConnection) =>
+        this.setPeerConnection(pc),
+      ),
+    );
+    this.viewport = viewport;
+    this.remote = remote;
+    this.remoteOnline = new SelectorController(this, this.remote, (state) =>
+      state.matches('root.online'),
+    );
+    this.frame = new SelectorController(
+      this,
+      this.remote,
+      (state) => state.context.frame,
+    );
+    this.bounds = new SelectorController(
+      this,
+      this.remote,
+      ({ context: { imageWorldBounds, clipBounds } }) => {
+        // Compute normalized bounds
+        const ranges = chunk(2, imageWorldBounds).map(
+          ([min, max]) => max - min,
+        );
+        const normalizedBounds = clipBounds.map(
+          (worldBound, index) =>
+            (100 * worldBound) / ranges[Math.floor(index / 2)],
+        );
+        const clipBoundsWithNormalized = clipBounds.map(
+          (bound, i) => [bound, normalizedBounds[i]] as const,
+        );
+
+        return { imageWorldBounds, clipBounds, clipBoundsWithNormalized };
+      },
+      (a, b) => {
+        if (!a || !b) return false;
+        return (
+          a.imageWorldBounds === b.imageWorldBounds &&
+          a.clipBounds === b.clipBounds
+        );
+      },
+    );
+  }
+
+  protected setPeerConnection(pc: RTCPeerConnection) {
+    this.peerConnection = pc;
+
+    // connect audio / video
+    this.peerConnection.addEventListener('track', (evt: RTCTrackEvent) => {
+      this.canvas.value!.srcObject = evt.streams[0];
+    });
+
+    const frameRate = 10;
+    // @ts-expect-error need to call getContext for Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1572422
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const canvasCtx = this.hostCanvas.getContext('2d');
+    const stream = this.hostCanvas.captureStream(frameRate);
+    for (const track of stream.getVideoTracks()) {
+      this.peerConnection.addTrack(track, stream);
+    }
+  }
+
+  startRenderLoop() {
+    if (this.renderLoopRunning || !this.remoteOnline.value) return;
+    this.renderLoopRunning = true;
+
+    const render = () => {
+      const remoteSnap = this.remote.getSnapshot();
+      if (!this.isConnected || remoteSnap.status === 'stopped') {
+        this.renderLoopRunning = false;
+        return;
+      }
+
+      this.remote.send({ type: 'render' });
+      requestAnimationFrame(render);
+    };
+    requestAnimationFrame(render);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.startRenderLoop();
+  }
+
+  firstUpdated() {
+    this.resizer.observe(this.canvas.value!);
+  }
+
+  startConnection(): void {
+    if (!this.serverConfig) return;
+
+    this.remote.send({
+      type: 'connect',
+      config: this.serverConfig,
+    });
+  }
+
+  willUpdate(changedProperties: PropertyValues<this>) {
+    if (changedProperties.has('serverConfig')) {
+      this.startConnection();
+    }
+
+    if (changedProperties.has('density')) {
+      this.remote.send({
+        type: 'updateRenderer',
+        state: { density: this.density },
+      });
+    }
+
+    if (this.remoteOnline.value !== this.lastRemoteOnlineValue) {
+      this.lastRemoteOnlineValue = this.remoteOnline.value;
+      if (this.remoteOnline.value) {
+        this.startRenderLoop();
+      }
+    }
+  }
+
+  onDensity(event: Event) {
+    const target = event.target as HTMLInputElement;
+    this.density = target.valueAsNumber;
+  }
+
+  onBounds(event: Event, index: number) {
+    const target = event.target as HTMLInputElement;
+    const normalizedBound = target.valueAsNumber;
+    // Find dimension range to go from normalized to world bounds
+    const { imageWorldBounds } = this.remote.getSnapshot().context;
+    if (!imageWorldBounds) {
+      console.error('No image world bounds');
+      return;
+    }
+    const [lowerBound, upperBound] =
+      index % 2 === 0 ? [index, index + 1] : [index - 1, index];
+    const range = imageWorldBounds[upperBound] - imageWorldBounds[lowerBound];
+    const floor = imageWorldBounds[lowerBound];
+    const currentBounds = [
+      ...this.remote.getSnapshot().context.clipBounds,
+    ] as Bounds;
+    currentBounds[index] = range * (normalizedBound / 100) + floor;
+
+    this.remote.send({
+      type: 'setClipBounds',
+      clipBounds: currentBounds,
+    });
+  }
+
+  render() {
+    return html`
+      <h1>Remote viewport</h1>
+      <p>Server Config: ${JSON.stringify(this.serverConfig)}</p>
+      <div>
+        Density: ${this.density}
+        <input
+          .valueAsNumber=${this.density}
+          @change="${this.onDensity}"
+          type="range"
+          min="1.0"
+          max="70.0"
+          step="1.0"
+        />
+      </div>
+
+      ${this.bounds.value.clipBoundsWithNormalized.map(
+        ([world, normalized], index) => html`
+          <label
+            >Bound: ${world}
+            <input
+              .valueAsNumber=${normalized}
+              @change="${(e: Event) => this.onBounds(e, index)}"
+              type="range"
+              min="0"
+              max="100.0"
+              step="1"
+            />
+          </label>
+        `,
+      )}
+
+      <itk-camera ${ref(this.camera)} .viewport=${this.viewport} class="camera">
+        <video
+          ${ref(this.canvas)}
+          autoplay="true"
+          playsinline="true"
+          class="canvas"
+          muted
+        ></video>
+      </itk-camera>
+    `;
+  }
+
+  static styles = css`
+    :host {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .camera {
+      flex: 1;
+      min-height: 0;
+      overflow: hidden;
+    }
+
+    .canvas {
+      width: 100%;
+      height: 100%;
+    }
+  `;
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'itk-remote-viewport-webrtc': ItkRemoteViewport;
+  }
+}

--- a/packages/remote-viewport/src/remote-viewport.ts
+++ b/packages/remote-viewport/src/remote-viewport.ts
@@ -4,7 +4,10 @@ import { ReadonlyMat4, mat4, vec3 } from 'gl-matrix';
 import { decode, Image } from '@itk-wasm/htj2k';
 import { RendererEntries, remoteMachine, Context } from './remote-machine.js';
 import { XYZ } from '@itk-viewer/io/dimensionUtils.js';
-import { worldBoundsToIndexBounds } from '@itk-viewer/io/MultiscaleSpatialImage.js';
+import {
+  MultiscaleSpatialImage,
+  worldBoundsToIndexBounds,
+} from '@itk-viewer/io/MultiscaleSpatialImage.js';
 import { Bounds } from '@itk-viewer/io/types.js';
 import { transformBounds } from '@itk-viewer/io/transformBounds.js';
 
@@ -21,6 +24,7 @@ type RenderedFrame = {
 type Renderer = {
   updateRenderer: (events: unknown) => unknown;
   render: () => Promise<{ frame: Uint8Array; renderTime: number }>;
+  getRenderTime: () => Promise<{ renderTime: number }>;
 };
 
 type MachineContext = Omit<Context, 'server'> & { server: Renderer };
@@ -42,7 +46,12 @@ type HyphaServiceConfig = {
   serviceId: string;
 };
 
-const createHyphaRenderer = async (context: Context) => {
+type PeerConnectionInitCallback = ((pc: RTCPeerConnection) => void) | undefined;
+
+const createHyphaRenderer = async (
+  context: Context,
+  onPeerConnctionInit: PeerConnectionInitCallback,
+) => {
   const { serverUrl, serviceId } = context.serverConfig as HyphaServiceConfig;
   if (!serverUrl) {
     throw new Error('No server url provided');
@@ -53,7 +62,10 @@ const createHyphaRenderer = async (context: Context) => {
     server_url: serverUrl,
   });
 
-  const pc = await hyphaWebsocketClient.getRTCService(server, serviceId);
+  const pc = await hyphaWebsocketClient.getRTCService(server, serviceId, {
+    on_init: onPeerConnctionInit,
+  });
+
   const renderer = await pc.getService(RENDERER_SERVICE_ID);
   await renderer.setup();
 
@@ -111,13 +123,15 @@ const makeLoadImageCommand = ([type, payload]: Command, context: Context) => {
   ] as Command;
 };
 
-export const createHyphaMachineConfig: () => RemoteMachineOptions = () => {
+export const createHyphaMachineConfig = (
+  peerConnectionInitCallback: PeerConnectionInitCallback = undefined,
+) => {
   let decodeWorker: Worker | null = null;
 
   return {
     actors: {
       connect: fromPromise(async ({ input }: { input: ConnectInput }) =>
-        createHyphaRenderer(input.context),
+        createHyphaRenderer(input.context, peerConnectionInitCallback),
       ),
       commandSender: fromPromise(
         async ({ input: { context, commands } }: { input: RendererInput }) => {
@@ -168,12 +182,16 @@ export const createHyphaMachineConfig: () => RemoteMachineOptions = () => {
           context.server.updateRenderer(translatedCommands);
         },
       ),
-      renderer: fromPromise(
+      renderer: fromPromise<unknown, { context: MachineContext }>(
         async ({
           input: {
             context: { server },
           },
         }) => {
+          if (peerConnectionInitCallback) {
+            const { renderTime } = await server.getRenderTime();
+            return { renderTime };
+          }
           const { frame: encodedImage, renderTime } = await server.render();
           const { image: frame, webWorker } = await decode(
             decodeWorker,
@@ -185,49 +203,54 @@ export const createHyphaMachineConfig: () => RemoteMachineOptions = () => {
         },
       ),
       // Computes world bounds and transform from VTK to Agave coordinate system
-      imageProcessor: fromPromise(
-        async ({ input: { image, imageScale, clipBounds } }) => {
-          const indexToWorld = await image.scaleIndexToWorld(imageScale);
-          const imageWorldToIndex = mat4.invert(mat4.create(), indexToWorld);
+      imageProcessor: fromPromise<
+        unknown,
+        {
+          image: MultiscaleSpatialImage;
+          imageScale: number;
+          clipBounds: Bounds;
+        }
+      >(async ({ input: { image, imageScale, clipBounds } }) => {
+        const indexToWorld = await image.scaleIndexToWorld(imageScale);
+        const imageWorldToIndex = mat4.invert(mat4.create(), indexToWorld);
 
-          const fullIndexBounds = image.getIndexBounds(imageScale);
-          const byDim = worldBoundsToIndexBounds({
-            bounds: clipBounds,
-            fullIndexBounds,
-            worldToIndex: imageWorldToIndex,
-          });
+        const fullIndexBounds = image.getIndexBounds(imageScale);
+        const byDim = worldBoundsToIndexBounds({
+          bounds: clipBounds,
+          fullIndexBounds,
+          worldToIndex: imageWorldToIndex,
+        });
 
-          // loaded image world bounds
-          const bounds = transformBounds(
-            indexToWorld,
-            XYZ.flatMap((dim) => byDim.get(dim)) as Bounds,
-          );
+        // loaded image world bounds
+        const bounds = transformBounds(
+          indexToWorld,
+          XYZ.flatMap((dim) => byDim.get(dim)) as Bounds,
+        );
 
-          // Remove image origin offset to world origin
-          const imageOrigin = vec3.fromValues(bounds[0], bounds[2], bounds[4]);
-          const transform = mat4.fromTranslation(mat4.create(), imageOrigin);
+        // Remove image origin offset to world origin
+        const imageOrigin = vec3.fromValues(bounds[0], bounds[2], bounds[4]);
+        const transform = mat4.fromTranslation(mat4.create(), imageOrigin);
 
-          // match Agave by normalizing to largest dim
-          const wx = bounds[1] - bounds[0];
-          const wy = bounds[3] - bounds[2];
-          const wz = bounds[5] - bounds[4];
-          const maxDim = Math.max(wx, wy, wz);
-          const scale = vec3.fromValues(maxDim, maxDim, maxDim);
-          mat4.scale(transform, transform, scale);
+        // match Agave by normalizing to largest dim
+        const wx = bounds[1] - bounds[0];
+        const wy = bounds[3] - bounds[2];
+        const wz = bounds[5] - bounds[4];
+        const maxDim = Math.max(wx, wy, wz);
+        const scale = vec3.fromValues(maxDim, maxDim, maxDim);
+        mat4.scale(transform, transform, scale);
 
-          // invert to go from VTK to Agave
-          mat4.invert(transform, transform);
+        // invert to go from VTK to Agave
+        mat4.invert(transform, transform);
 
-          const fullWorldBounds = await image.getWorldBounds(imageScale);
-          return {
-            toRendererCoordinateSystem: transform,
-            bounds: fullWorldBounds,
-            image,
-            imageScale,
-            imageWorldToIndex,
-          };
-        },
-      ),
+        const fullWorldBounds = await image.getWorldBounds(imageScale);
+        return {
+          toRendererCoordinateSystem: transform,
+          bounds: fullWorldBounds,
+          image,
+          imageScale,
+          imageWorldToIndex,
+        };
+      }),
     },
   };
 };


### PR DESCRIPTION
Copies and applies small changes to `itk-remote-viewport` to make `itk-remote-viewport-webrtc`.  Server side, rather than Hypha RPC `render` call triggering an Agave render, `class VideoTransformTrack` continually calls Agave render function.