### PR TITLE
Use viewport aspect in 3D view reset.  Fix view-2d when viewing 3D image.

### DIFF
--- a/packages/element/examples/compare.html
+++ b/packages/element/examples/compare.html
@@ -10,6 +10,8 @@
     <script type="module" src="../src/itk-viewport.ts"></script>
     <script type="module" src="../src/itk-view-2d.ts"></script>
     <script type="module" src="../src/itk-view-2d-vtkjs.ts"></script>
+    <script type="module" src="../src/itk-view-3d.ts"></script>
+    <script type="module" src="../src/itk-view-3d-vtkjs.ts"></script>
 
     <script type="module" src="./compare.ts"></script>
   </head>

--- a/packages/element/examples/multi-views.html
+++ b/packages/element/examples/multi-views.html
@@ -8,12 +8,11 @@
     <link rel="stylesheet" href="index.css" />
     <script type="module" src="../src/itk-viewer-element.ts"></script>
     <!-- avoid error: the name "itk-viewport" has already been used with this registry -->
-    <!-- <script type="module" src="../src/itk-viewport.ts"></script> -->
-    <script type="module" src="../src/itk-image-info-viewport.ts"></script>
+    <script type="module" src="../src/itk-viewport.ts"></script>
+    <!-- <script type="module" src="../src/itk-image-info-viewport.ts"></script> -->
     <script type="module" src="../src/itk-view-2d.ts"></script>
     <script type="module" src="../src/itk-view-2d-vtkjs.ts"></script>
     <script type="module" src="../src/itk-view-3d.ts"></script>
-    <script type="module" src="../src/itk-view-3d-vtkjs.ts"></script>
     <script type="module" src="multi-views.ts"></script>
   </head>
 
@@ -21,9 +20,7 @@
     <itk-viewer class="fill">
       <div class="fill row">
         <itk-viewport class="fill">
-          <itk-view-3d class="fill">
-            <itk-view-3d-vtkjs></itk-view-3d-vtkjs>
-          </itk-view-3d>
+          <itk-view-3d renderer="vtkjs" class="fill"></itk-view-3d>
         </itk-viewport>
         <div class="fill">
           <!-- <itk-image-info-viewport></itk-image-info-viewport> -->

--- a/packages/element/examples/multi-views.ts
+++ b/packages/element/examples/multi-views.ts
@@ -6,29 +6,31 @@ setPipelineWorkerUrl(pipelineWorkerUrl);
 const pipelineBaseUrl = '/itk/pipelines';
 setPipelinesBaseUrl(pipelineBaseUrl);
 
-document.addEventListener('DOMContentLoaded', async function () {
-  const imagePath = '/ome-ngff-prototypes/single_image/v0.4/zyx.ome.zarr';
+const makeZarrImage = (imagePath: string) => {
   const url = new URL(imagePath, document.location.origin);
-  const image = await ZarrMultiscaleSpatialImage.fromUrl(url);
+  return ZarrMultiscaleSpatialImage.fromUrl(url);
+};
+
+document.addEventListener('DOMContentLoaded', async function () {
+  const image = await makeZarrImage(
+    '/ome-ngff-prototypes/single_image/v0.4/zyx.ome.zarr',
+  );
 
   const viewerElement = document.querySelector('itk-viewer');
   if (!viewerElement) throw new Error('Could not find element');
   const viewer = viewerElement.getActor();
   viewer.send({ type: 'setImage', image, name: 'image' });
 
-  const bigView = document.querySelectorAll('itk-view-2d')[0];
-  bigView.getActor()?.send({ type: 'setScale', scale: 0 });
+  const first2d = document.querySelectorAll('itk-view-2d')[0];
+  first2d.getActor()?.send({ type: 'setScale', scale: 0 });
 
-  const lastView = document.querySelectorAll('itk-viewport')[2];
-  if (!lastView) throw new Error('Could not find viewport element');
-  const viewActor = lastView.getActor();
-  if (!viewActor) throw new Error('No view actor');
-
-  const image2dUrl = new URL(
+  const image2d = await makeZarrImage(
     '/ome-ngff-prototypes/single_image/v0.4/tyx.ome.zarr',
-    document.location.origin,
   );
-  const image2d = await ZarrMultiscaleSpatialImage.fromUrl(image2dUrl);
+  const lastViewport = document.querySelectorAll('itk-viewport')[2];
+  if (!lastViewport) throw new Error('Could not find viewport element');
+  const viewActor = lastViewport.getActor();
+  if (!viewActor) throw new Error('No view actor');
   viewActor.send({ type: 'setImage', image: image2d });
   // viewActor.send({ type: 'setSlice', slice: 0.8 });
 });

--- a/packages/element/examples/view-3d-2d.html
+++ b/packages/element/examples/view-3d-2d.html
@@ -19,9 +19,7 @@
   <body>
     <itk-viewer class="fill" style="flex-direction: row; gap: 0.25rem">
       <itk-viewport class="fill">
-        <itk-view-3d class="fill">
-          <itk-view-3d-vtkjs></itk-view-3d-vtkjs>
-        </itk-view-3d>
+        <itk-view-3d renderer="vtkjs" class="fill"> </itk-view-3d>
       </itk-viewport>
       <itk-viewport class="fill">
         <itk-view-2d class="fill">

--- a/packages/element/examples/view-3d-2d.html
+++ b/packages/element/examples/view-3d-2d.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Compare</title>
+    <link rel="stylesheet" href="index.css" />
+    <script type="module" src="../src/itk-viewer-element.ts"></script>
+    <script type="module" src="../src/itk-viewport.ts"></script>
+    <script type="module" src="../src/itk-view-2d.ts"></script>
+    <script type="module" src="../src/itk-view-2d-vtkjs.ts"></script>
+    <script type="module" src="../src/itk-view-3d.ts"></script>
+    <script type="module" src="../src/itk-view-3d-vtkjs.ts"></script>
+
+    <script type="module" src="./compare.ts"></script>
+  </head>
+
+  <body>
+    <itk-viewer class="fill" style="flex-direction: row; gap: 0.25rem">
+      <itk-viewport class="fill">
+        <itk-view-3d class="fill">
+          <itk-view-3d-vtkjs></itk-view-3d-vtkjs>
+        </itk-view-3d>
+      </itk-viewport>
+      <itk-viewport class="fill">
+        <itk-view-2d class="fill">
+          <itk-view-2d-vtkjs></itk-view-2d-vtkjs>
+        </itk-view-2d>
+      </itk-viewport>
+    </itk-viewer>
+  </body>
+</html>

--- a/packages/element/examples/view-3d.html
+++ b/packages/element/examples/view-3d.html
@@ -9,7 +9,6 @@
     <script type="module" src="../src/itk-viewer-element.ts"></script>
     <script type="module" src="../src/itk-viewport.ts"></script>
     <script type="module" src="../src/itk-view-3d.ts"></script>
-    <script type="module" src="../src/itk-view-3d-vtkjs.ts"></script>
 
     <script type="module" src="./view-3d.ts"></script>
   </head>
@@ -17,9 +16,7 @@
   <body>
     <itk-viewer class="fill">
       <itk-viewport class="fill">
-        <itk-view-3d class="fill">
-          <itk-view-3d-vtkjs></itk-view-3d-vtkjs>
-        </itk-view-3d>
+        <itk-view-3d renderer="vtkjs" class="fill"></itk-view-3d>
       </itk-viewport>
     </itk-viewer>
   </body>

--- a/packages/element/src/itk-view-3d-vtkjs.ts
+++ b/packages/element/src/itk-view-3d-vtkjs.ts
@@ -5,9 +5,6 @@ import { Actor } from 'xstate';
 
 import { createLogic } from '@itk-viewer/vtkjs/view-3d-vtkjs.js';
 import { dispatchSpawn } from './spawn-controller.js';
-import { SelectorController } from 'xstate-lit';
-import { Camera } from '@itk-viewer/viewer/camera.js';
-import './itk-camera.js';
 
 type ComponentActor = Actor<ReturnType<typeof createLogic>>;
 
@@ -17,10 +14,6 @@ export class ItkView3dVtkjs extends LitElement {
   container: HTMLElement | undefined;
   dispatched = false;
 
-  cameraActor:
-    | SelectorController<ComponentActor, Camera | undefined>
-    | undefined;
-
   getActor() {
     return this.actor;
   }
@@ -28,11 +21,6 @@ export class ItkView3dVtkjs extends LitElement {
   protected setActor(actor: ComponentActor) {
     this.actor = actor;
     this.sendContainer();
-    this.cameraActor = new SelectorController(
-      this,
-      this.actor,
-      (state) => state.context.camera,
-    );
   }
 
   protected sendContainer() {
@@ -55,11 +43,7 @@ export class ItkView3dVtkjs extends LitElement {
       this.dispatched = true;
     }
 
-    return html`
-      <itk-camera .actor=${this.cameraActor?.value} class="container">
-        <div class="container" ${ref(this.onContainer)}></div>
-      </itk-camera>
-    `;
+    return html` <div class="container" ${ref(this.onContainer)}></div> `;
   }
 
   static styles = css`

--- a/packages/viewer/src/camera.ts
+++ b/packages/viewer/src/camera.ts
@@ -176,6 +176,7 @@ export const reset3d = (
   pose: Pose,
   verticalFieldOfView: number,
   bounds: Bounds,
+  aspect: number,
 ) => {
   const center = vec3.fromValues(
     (bounds[0] + bounds[1]) / 2.0,
@@ -195,7 +196,11 @@ export const reset3d = (
   // compute the radius of the enclosing sphere
   radius = Math.sqrt(radius) * 0.5;
 
-  const radians = verticalFieldOfView * (Math.PI / 180);
+  const limitingDegrees = Math.min(
+    verticalFieldOfView * aspect, // horizontal field of view
+    verticalFieldOfView,
+  );
+  const radians = limitingDegrees * (Math.PI / 180);
   const distance = radius / Math.sin(radians * 0.5);
 
   return { center, rotation: pose.rotation, distance };

--- a/packages/viewer/src/camera.ts
+++ b/packages/viewer/src/camera.ts
@@ -201,7 +201,7 @@ export const reset3d = (
     verticalFieldOfView,
   );
   const radians = limitingDegrees * (Math.PI / 180);
-  const distance = radius / Math.sin(radians * 0.5);
+  const distance = radius / Math.tan(radians * 0.5);
 
   return { center, rotation: pose.rotation, distance };
 };
@@ -219,9 +219,8 @@ export const reset2d = (
   );
 
   // Get the bounds in view coordinates
-  const visiblePoints = getCorners(bounds);
-
   const viewBounds = createBounds();
+  const visiblePoints = getCorners(bounds);
   const viewMat = mat4.create();
   toMat4(viewMat, pose);
   for (let i = 0; i < visiblePoints.length; ++i) {

--- a/packages/viewer/src/viewport.ts
+++ b/packages/viewer/src/viewport.ts
@@ -48,15 +48,17 @@ export const viewportMachine = setup({
         actor.send(event);
       });
     },
-    resetCameraPose: async ({ context: { image }, self }) => {
+    resetCameraPose: async ({ context: { image, resolution: dims }, self }) => {
       const { camera } = self.getSnapshot().children;
       if (!image || !camera) return;
 
+      const aspect = (() => {
+        return dims[1] && dims[0] ? dims[0] / dims[1] : 1;
+      })();
       const bounds = await image.getWorldBounds(image.coarsestScale);
       const { pose: currentPose, verticalFieldOfView } =
         camera.getSnapshot().context;
-      const pose = reset3d(currentPose, verticalFieldOfView, bounds);
-
+      const pose = reset3d(currentPose, verticalFieldOfView, bounds, aspect);
       camera.send({
         type: 'setPose',
         pose,

--- a/packages/vtkjs/src/view-2d-vtkjs.ts
+++ b/packages/vtkjs/src/view-2d-vtkjs.ts
@@ -107,9 +107,10 @@ const createImplementation = () => {
         event: AnyEventObject;
         context: Context;
       }) => {
-        const { image } = event;
+        const { image, sliceIndex } = event;
         const vtkImage = vtkITKHelper.convertItkToVtkImage(image);
         mapper!.setInputData(vtkImage);
+        mapper!.setSlice(sliceIndex);
 
         // add actor to renderer after mapper has data to avoid vtkjs message
         if (!addedActorToRenderer) {


### PR DESCRIPTION
- On camera reset, 3D view reset uses smaller viewport dimension to fit volume.
- Set view-2d's slice index to support 3D images.
- Set minium bound on view-2d-vtkjs camera pose distance to keep slice in front of camera.