### PR TITLE
build(element): build examples for deployment

### DIFF
--- a/packages/element/vite.config.ts
+++ b/packages/element/vite.config.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 
@@ -5,12 +6,21 @@ export default defineConfig({
   publicDir: '../../test/data/input',
   build: {
     outDir: 'examples/dist',
-    lib: {
-      entry: 'src/itk-viewer-element.ts',
-      formats: ['es'],
-    },
     rollupOptions: {
-      external: /^lit/,
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        compare: resolve(__dirname, 'examples/compare.html'),
+        imageIoReadImage: resolve(
+          __dirname,
+          'examples/image-io-read-image.html',
+        ),
+        multiViews: resolve(__dirname, 'examples/multi-views.html'),
+        remoteViewport: resolve(__dirname, 'examples/remote-viewport.html'),
+        remoteWebrtc: resolve(__dirname, 'examples/remote-webrtc.html'),
+        view2d: resolve(__dirname, 'examples/view-2d.html'),
+        view3d2d: resolve(__dirname, 'examples/view-3d-2d.html'),
+        view3d: resolve(__dirname, 'examples/view-3d.html'),
+      },
     },
   },
   server: {


### PR DESCRIPTION
Remove the unused `lib` entry and `external` rollupOption since the
library module is not used and this prevents HTML + asset output.

Add the multi-page entries to generate all HTML files per

  https://vitejs.dev/guide/build#multi-page-app
