### PR TITLE
fix(blosc-zarr): really ignore version.js

### DIFF
--- a/.changeset/nine-doors-confess.md
+++ b/.changeset/nine-doors-confess.md
@@ -1,0 +1,5 @@
+---
+'@itk-viewer/blosc-zarr': patch
+---
+
+Fix blosc-zarr npm publish by ignoring versions.js and adding .npmignore

--- a/packages/blosc-zarr/.npmignore
+++ b/packages/blosc-zarr/.npmignore
@@ -3,4 +3,3 @@
 /emscripten-build/*
 !emscripten-build/BloscZarr.*
 /emscripten-build/BloscZarr.umd.wasm
-/version.js

--- a/packages/blosc-zarr/version.js
+++ b/packages/blosc-zarr/version.js
@@ -1,1 +1,0 @@
-export const version = "0.2.0";


### PR DESCRIPTION
Add .npmignore to include version.js the package.