### PR TITLE
feat(element): add hide UI attributes

### DIFF
--- a/packages/element/src/itk-viewer-2d.ts
+++ b/packages/element/src/itk-viewer-2d.ts
@@ -1,5 +1,5 @@
 import { LitElement, css, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { Ref, createRef, ref } from 'lit/directives/ref.js';
 import './itk-viewer-element.js';
 import { ItkViewer } from './itk-viewer-element.js';
@@ -16,6 +16,18 @@ export class ItkViewer2d extends LitElement {
   view: Ref<ItkView2d> = createRef();
   controls: Ref<ViewControlsShoelace> = createRef();
 
+  @property({ type: Boolean })
+  hideSliceUi: boolean = false;
+
+  @property({ type: Boolean })
+  hideScaleUi: boolean = false;
+
+  @property({ type: Boolean })
+  hideColorUi: boolean = false;
+
+  @property({ type: Boolean })
+  hideTransferFunctionUi: boolean = false;
+
   getActor() {
     return this.viewer.value?.getActor();
   }
@@ -29,6 +41,10 @@ export class ItkViewer2d extends LitElement {
               <itk-view-controls-shoelace
                 view="2d"
                 ${ref(this.controls)}
+                ?hideSliceUi="${this.hideSliceUi}"
+                ?hideScaleUi="${this.hideScaleUi}"
+                ?hideColorUi="${this.hideColorUi}"
+                ?hideTransferFunctionUi="${this.hideTransferFunctionUi}"
               ></itk-view-controls-shoelace>
             </div>
             <itk-view-2d ${ref(this.view)} class="fill">

--- a/packages/element/src/itk-viewer-3d.ts
+++ b/packages/element/src/itk-viewer-3d.ts
@@ -1,5 +1,5 @@
 import { LitElement, css, html } from 'lit';
-import { customElement } from 'lit/decorators.js';
+import { customElement, property } from 'lit/decorators.js';
 import { Ref, createRef, ref } from 'lit/directives/ref.js';
 import './itk-viewer-element.js';
 import { ItkViewer } from './itk-viewer-element.js';
@@ -16,6 +16,15 @@ export class ItkViewer3d extends LitElement {
   view: Ref<ItkView3d> = createRef();
   controls: Ref<ViewControlsShoelace> = createRef();
 
+  @property({ type: Boolean })
+  hideScaleUi: boolean = false;
+
+  @property({ type: Boolean })
+  hideColorUi: boolean = false;
+
+  @property({ type: Boolean })
+  hideTransferFunctionUi: boolean = false;
+
   getActor() {
     return this.viewer.value?.getActor();
   }
@@ -29,6 +38,9 @@ export class ItkViewer3d extends LitElement {
               <itk-view-controls-shoelace
                 view="3d"
                 ${ref(this.controls)}
+                ?hideScaleUi="${this.hideScaleUi}"
+                ?hideColorUi="${this.hideColorUi}"
+                ?hideTransferFunctionUi="${this.hideTransferFunctionUi}"
               ></itk-view-controls-shoelace>
             </div>
             <itk-view-3d ${ref(this.view)} class="fill">


### PR DESCRIPTION
By default, we should all UI controls (likely the most commonly desired
value), but we provide support for element attributes to disable
components. Added to itk-view-controls-shoelace, itk-viewer-2d,
itk-viewer-3d.

- hideSliceUi
- hideScaleUi
- hideColorUi
- hideTransferFunctionUi
